### PR TITLE
Refine locking model and add debug caller/current sanity check

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -34,7 +34,7 @@ INPUT                  = src/tealet.h \
                          README.md \
                          docs/GETTING_STARTED.md \
                          docs/ARCHITECTURE.md \
-                         docs/INCEMENTAL_SAVE.md \
+                         docs/INCREMENTAL_SAVE.md \
                          docs/DOXYGEN.md \
                          docs/MEMORY_STATS.md
 FILE_PATTERNS          = *.h \

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ main-lineage and/or fork-originated.
 - **[API Reference](docs/API.md)** - Complete function reference
 - **[Doxygen Workflow](docs/DOXYGEN.md)** - Local authored+generated API docs setup
 - **[Architecture](docs/ARCHITECTURE.md)** - Internals and stack-chaining design
-- **[Incremental Save Algorithm](docs/INCEMENTAL_SAVE.md)** - Partial-save model, invariants, and transition diagrams
+- **[Incremental Save Algorithm](docs/INCREMENTAL_SAVE.md)** - Partial-save model, invariants, and transition diagrams
 - **[Changelog](CHANGELOG.md)** - Version history
 
 ## Performance Characteristics

--- a/docs/API.md
+++ b/docs/API.md
@@ -895,7 +895,18 @@ The descriptor is copied into internal main-tealet state. Pass `NULL` to clear i
 
 **Recommendation:** Call this immediately after `tealet_initialize()` and before sharing tealet handles across threads. This avoids races where foreign-thread delete operations run before lock callbacks are installed.
 
-When configured, libtealet uses these callbacks to serialize internal structure mutations that can overlap with foreign-thread lifecycle operations. In particular, switching and delete paths coordinate through the same lock domain so delete does not race active switch bookkeeping.
+When configured, libtealet automatically acquires/releases this lock only for the core switching APIs:
+- `tealet_new()`
+- `tealet_create()`
+- `tealet_switch()`
+- `tealet_exit()`
+- `tealet_fork()`
+
+Rationale: these paths are temporally asymmetric (execution may leave one call site and later continue from a different logical point, including entry/exit boundaries). Keeping lock ownership inside the library for these transitions avoids brittle cross-frame lock management in integrator code.
+
+Stub helpers in `tealet_extras.h` (`tealet_stub_new()`, `tealet_stub_run()`) are switching wrappers by inference, so they inherit this behavior through the core switching APIs.
+
+For other APIs, integrators should call `tealet_lock()`/`tealet_unlock()` explicitly when foreign-thread access is possible.
 
 **Allocator interaction contract:** libtealet may invoke allocator callbacks either with or without the configured tealet lock held, depending on internal call path. Integrators must not rely on the tealet lock as allocator protection, and allocator implementations must avoid deadlocking in either state.
 
@@ -916,7 +927,9 @@ Invoke the configured locking callbacks for the tealet domain.
 
 These helpers are intended for synchronizing access to tealet structures for the primary multi-threaded use case: foreign-thread `tealet_delete()` of non-main tealets.
 
-Configuration, `tealet_duplicate()`, and context switching remain single-thread responsibilities. In particular, switching between related tealets from different threads is unsupported: a tealet domain must be switched by one thread at a time, and cross-thread `tealet_switch()` usage is invalid.
+Only the five core switching APIs are auto-locked by libtealet (`tealet_new()`, `tealet_create()`, `tealet_switch()`, `tealet_exit()`, `tealet_fork()`). For other APIs (for example `tealet_delete()` and `tealet_duplicate()`), integrators are expected to apply explicit lock/unlock around calls if those operations may run from foreign threads.
+
+Switching itself remains thread-affine: switching between related tealets from different threads is unsupported, and cross-thread `tealet_switch()` usage is invalid.
 
 Use a real cross-thread mutex (or equivalent) for these callbacks if you share handles across threads. No-op or thread-local locks do not provide inter-thread safety.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -862,6 +862,46 @@ This helper is intended as a simple one-way "enable checks" API; use `tealet_con
 
 ---
 
+### `tealet_config_set_locking()`
+
+```c
+int tealet_config_set_locking(tealet_t *tealet, const tealet_lock_t *locking);
+```
+
+Configure optional lock/unlock callbacks for a main-tealet domain.
+
+`tealet_lock_t` contains:
+- `void (*lock)(void *arg)`
+- `void (*unlock)(void *arg)`
+- `void *arg`
+
+The descriptor is copied into internal main-tealet state. Pass `NULL` to clear it.
+
+**Recommendation:** Call this immediately after `tealet_initialize()` and before sharing tealet handles across threads. This avoids races where concurrent lifecycle operations run before lock callbacks are installed.
+
+**Allocator interaction contract:** libtealet may invoke allocator callbacks either with or without the configured tealet lock held, depending on internal call path. Integrators must not rely on the tealet lock as allocator protection, and allocator implementations must avoid deadlocking in either state.
+
+---
+
+### `tealet_lock()` / `tealet_unlock()`
+
+```c
+void tealet_lock(tealet_t *tealet);
+void tealet_unlock(tealet_t *tealet);
+```
+
+Invoke the configured locking callbacks for the tealet domain.
+
+**Behavior:**
+- If lock callbacks are configured, these forward to them with the configured `arg`.
+- If callbacks are not configured, both APIs are no-ops.
+
+These helpers are intended for synchronizing access to tealet structures and lifecycle operations (for example duplicate/delete) in multi-threaded integrations.
+
+They do not make context switching itself multi-thread-safe. In particular, switching between related tealets from different threads is unsupported: a tealet domain must be switched by one thread at a time, and cross-thread `tealet_switch()` usage is invalid.
+
+---
+
 ### `tealet_delete()`
 
 ```c
@@ -910,6 +950,8 @@ typedef struct tealet_alloc {
 ```
 
 Custom memory allocator interface.
+
+Allocator callbacks may be invoked either with or without the configured tealet lock held. Design allocators to be safe in both contexts and do not assume lock state.
 
 **Fields:**
 - `context`: User-defined allocator state (passed to malloc/free functions)

--- a/docs/API.md
+++ b/docs/API.md
@@ -528,6 +528,9 @@ If the chosen exit target is defunct, this fallback path reroutes the exit to `m
 
 ## Status and Inspection
 
+Query APIs in this section may be called from foreign threads, but they do not
+guarantee a globally consistent snapshot of tealet state.
+
 ### `tealet_previous()`
 
 ```c
@@ -543,6 +546,9 @@ Get the tealet that most recently switched to the current tealet.
 - Pointer to the previous tealet when available
 - `NULL` when no previous tealet is recorded
 - `NULL` when the previously recorded tealet has been destroyed
+
+**Note:** In a multithreaded setting, a previous tealet can be simultaneously
+deleted by a different thread, invalidating the returned pointer.
 
 **Usage:**
 ```c
@@ -664,6 +670,16 @@ Convenience macros are also available:
 
 - `TEALET_IS_MAIN_LINEAGE(t)`
 - `TEALET_IS_FORK(t)`
+
+---
+
+### `tealet_main_userpointer()`
+
+```c
+void **tealet_main_userpointer(tealet_t *tealet);
+```
+
+Get the address of the per-main user pointer slot.
 
 ---
 
@@ -877,7 +893,9 @@ Configure optional lock/unlock callbacks for a main-tealet domain.
 
 The descriptor is copied into internal main-tealet state. Pass `NULL` to clear it.
 
-**Recommendation:** Call this immediately after `tealet_initialize()` and before sharing tealet handles across threads. This avoids races where concurrent lifecycle operations run before lock callbacks are installed.
+**Recommendation:** Call this immediately after `tealet_initialize()` and before sharing tealet handles across threads. This avoids races where foreign-thread delete operations run before lock callbacks are installed.
+
+When configured, libtealet uses these callbacks to serialize internal structure mutations that can overlap with foreign-thread lifecycle operations. In particular, switching and delete paths coordinate through the same lock domain so delete does not race active switch bookkeeping.
 
 **Allocator interaction contract:** libtealet may invoke allocator callbacks either with or without the configured tealet lock held, depending on internal call path. Integrators must not rely on the tealet lock as allocator protection, and allocator implementations must avoid deadlocking in either state.
 
@@ -896,9 +914,11 @@ Invoke the configured locking callbacks for the tealet domain.
 - If lock callbacks are configured, these forward to them with the configured `arg`.
 - If callbacks are not configured, both APIs are no-ops.
 
-These helpers are intended for synchronizing access to tealet structures and lifecycle operations (for example duplicate/delete) in multi-threaded integrations.
+These helpers are intended for synchronizing access to tealet structures for the primary multi-threaded use case: foreign-thread `tealet_delete()` of non-main tealets.
 
-They do not make context switching itself multi-thread-safe. In particular, switching between related tealets from different threads is unsupported: a tealet domain must be switched by one thread at a time, and cross-thread `tealet_switch()` usage is invalid.
+Configuration, `tealet_duplicate()`, and context switching remain single-thread responsibilities. In particular, switching between related tealets from different threads is unsupported: a tealet domain must be switched by one thread at a time, and cross-thread `tealet_switch()` usage is invalid.
+
+Use a real cross-thread mutex (or equivalent) for these callbacks if you share handles across threads. No-op or thread-local locks do not provide inter-thread safety.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -528,8 +528,11 @@ If the chosen exit target is defunct, this fallback path reroutes the exit to `m
 
 ## Status and Inspection
 
-Query APIs in this section may be called from foreign threads, but they do not
-guarantee a globally consistent snapshot of tealet state.
+Query APIs in this section are not internally synchronized.
+
+If they are used from foreign threads, or concurrently with switching/lifecycle
+operations, callers must provide external synchronization (for example
+`tealet_lock()`/`tealet_unlock()` around the access sequence).
 
 ### `tealet_previous()`
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,17 +76,21 @@ libtealet implements **symmetric coroutines** through stack-slicing: saving port
 libtealet uses a **single-threaded switching model**: a switch operation must execute on exactly one thread within a main-tealet domain.
 
 At the same time, some lifecycle operations can be initiated from multiple threads in real integrations, especially:
-- Duplicating tealet structures
-- Deleting tealet structures
-- Inspecting and updating shared tealet metadata
+- Deleting tealet structures from a foreign thread
 
 This creates a mixed concurrency requirement:
-- **Context switching is not multi-threaded** and must remain serialized by design.
-- **Structure access and lifecycle management may be multi-threaded** and therefore require synchronization support.
+- **Configuration and context switching are single-threaded responsibilities** in a main-tealet domain.
+- **Multi-thread support is primarily for foreign-thread deletion of non-main tealets** (`tealet_delete()`).
 
-For this reason, libtealet should provide **locking helpers** around tealet structure access so library users can make metadata and lifecycle operations thread-safe without changing the core single-threaded switch semantics.
+For this reason, libtealet should provide **locking helpers** around tealet structure access so library users can safely coordinate foreign-thread delete operations without changing the core single-threaded switch semantics.
 
 In short: switching stays thread-affine, while auxiliary structure operations need explicit thread-safety support.
+
+Current implementation strategy:
+- A broad lock wraps the full switch transaction (save/restore plus switch bookkeeping).
+- Stack and tealet refcount/active-count updates that are relevant to delete races are performed under that same lock domain.
+
+This means foreign-thread `tealet_delete()` is serialized against active switching work, provided the configured lock callbacks implement real cross-thread mutual exclusion.
 
 ## Core Data Structures
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,6 +71,23 @@ This abstraction allows the same algorithm to work regardless of platform stack 
 
 libtealet implements **symmetric coroutines** through stack-slicing: saving portions of the C execution stack to the heap and restoring them later. The innovation lies in **incremental stack saving** that minimizes memory usage.
 
+## Threading Model and Locking Rationale
+
+libtealet uses a **single-threaded switching model**: a switch operation must execute on exactly one thread within a main-tealet domain.
+
+At the same time, some lifecycle operations can be initiated from multiple threads in real integrations, especially:
+- Duplicating tealet structures
+- Deleting tealet structures
+- Inspecting and updating shared tealet metadata
+
+This creates a mixed concurrency requirement:
+- **Context switching is not multi-threaded** and must remain serialized by design.
+- **Structure access and lifecycle management may be multi-threaded** and therefore require synchronization support.
+
+For this reason, libtealet should provide **locking helpers** around tealet structure access so library users can make metadata and lifecycle operations thread-safe without changing the core single-threaded switch semantics.
+
+In short: switching stays thread-affine, while auxiliary structure operations need explicit thread-safety support.
+
 ## Core Data Structures
 
 ### tealet_chunk_t - Stack Segment

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -79,18 +79,27 @@ At the same time, some lifecycle operations can be initiated from multiple threa
 - Deleting tealet structures from a foreign thread
 
 This creates a mixed concurrency requirement:
-- **Configuration and context switching are single-threaded responsibilities** in a main-tealet domain.
-- **Multi-thread support is primarily for foreign-thread deletion of non-main tealets** (`tealet_delete()`).
+- **Configuration and switching remain thread-affine** in a main-tealet domain.
+- **Some non-switch lifecycle operations may still be invoked from foreign threads** in real integrations.
 
-For this reason, libtealet should provide **locking helpers** around tealet structure access so library users can safely coordinate foreign-thread delete operations without changing the core single-threaded switch semantics.
+For this reason, libtealet exposes **locking helpers** and applies automatic internal locking only to the five switching APIs:
+- `tealet_new()`
+- `tealet_create()`
+- `tealet_switch()`
+- `tealet_exit()`
+- `tealet_fork()`
 
-In short: switching stays thread-affine, while auxiliary structure operations need explicit thread-safety support.
+Rationale: these APIs are temporally asymmetric. Execution can enter through one call boundary and continue from a different logical point (including tealet entry/exit boundaries). Centralizing lock ownership for these transitions inside the library avoids difficult cross-frame lock bookkeeping in integrator code.
+
+Stub helpers in `tealet_extras.h` are switching wrappers by inference and inherit this behavior through the core switching APIs.
+
+In short: switching lock complexity is handled internally for the five switching APIs, while auxiliary structure operations need explicit integrator-managed locking when foreign-thread calls are possible.
 
 Current implementation strategy:
-- A broad lock wraps the full switch transaction (save/restore plus switch bookkeeping).
-- Stack and tealet refcount/active-count updates that are relevant to delete races are performed under that same lock domain.
+- The switching APIs above acquire/release the configured lock around their transition work.
+- Non-switch APIs do not imply automatic synchronization.
 
-This means foreign-thread `tealet_delete()` is serialized against active switching work, provided the configured lock callbacks implement real cross-thread mutual exclusion.
+This means integrators should explicitly bracket calls such as `tealet_delete()` or `tealet_duplicate()` with `tealet_lock()`/`tealet_unlock()` when those calls may come from foreign threads.
 
 ## Core Data Structures
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -664,7 +664,7 @@ For a low-level C library, reference counting fits better.
 
 - [GETTING_STARTED.md](GETTING_STARTED.md) - Practical usage examples
 - [API.md](API.md) - Complete function reference
-- [INCEMENTAL_SAVE.md](INCEMENTAL_SAVE.md) - Partial-save algorithm and invariants
+- [INCREMENTAL_SAVE.md](INCREMENTAL_SAVE.md) - Partial-save algorithm and invariants
 - [stackman documentation](https://github.com/stackless-dev/stackman) - Low-level stack operations
 - [Stackless Python](https://github.com/stackless-dev/stackless) - Original inspiration
 - [Greenlet](https://greenlet.readthedocs.io/) - Related Python project

--- a/docs/INCREMENTAL_SAVE.md
+++ b/docs/INCREMENTAL_SAVE.md
@@ -133,7 +133,11 @@ Effect summary:
 
 Under this algorithm, unsaved memory for partial stacks is naturally expressed
 as disjoint staircase bands in the descending case.  This means that it is not
-possible to share saved chunks between different stacks.  Each additionally
-saved chunk is unique to a particular suspended Tealet.
+possible to share newly grown chunks between different stack objects.  Each
+additionally saved chunk belongs to one suspended stack instance.
+
+Tealets duplicated with `tealet_duplicate()` can still share the same saved
+stack object via stack reference counting; this is object sharing, not overlap
+between independently grown partial stacks.
 
 

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1868,6 +1868,7 @@ void tealet_delete(tealet_t *target) {
 
 tealet_t *tealet_current(tealet_t *tealet) {
   tealet_main_t *g_main = TEALET_GET_MAIN(tealet);
+  tealet_verify_current_matches_caller(g_main->g_current);
   return (tealet_t *)g_main->g_current;
 }
 

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1868,7 +1868,6 @@ void tealet_delete(tealet_t *target) {
 
 tealet_t *tealet_current(tealet_t *tealet) {
   tealet_main_t *g_main = TEALET_GET_MAIN(tealet);
-  tealet_verify_current_matches_caller(g_main->g_current);
   return (tealet_t *)g_main->g_current;
 }
 

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -144,6 +144,7 @@ typedef struct tealet_main_t {
   tealet_sub_t *g_target;   /* Temporary store when switching */
   void *g_arg;              /* argument passed around when switching */
   tealet_alloc_t g_alloc;   /* the allocation context used */
+  tealet_lock_t g_locking;  /* optional external lock callbacks */
   tealet_stack_t *g_prev;   /* previously active unsaved stacks */
   tealet_sr_e g_sw;         /* save/restore state */
   int g_flags;              /* default flags when tealet exits */
@@ -1438,6 +1439,9 @@ tealet_t *tealet_initialize(tealet_alloc_t *alloc, size_t extrasize) {
   g_main->g_target = NULL;
   g_main->g_arg = NULL;
   g_main->g_alloc = *alloc;
+  g_main->g_locking.lock = NULL;
+  g_main->g_locking.unlock = NULL;
+  g_main->g_locking.arg = NULL;
   g_main->g_prev = NULL;
   g_main->g_extrasize = extrasize;
   g_main->g_sw = SW_NOP;
@@ -1966,6 +1970,20 @@ int tealet_configure_set(tealet_t *_tealet, tealet_config_t *config) {
   return 0;
 }
 
+int tealet_config_set_locking(tealet_t *_tealet, const tealet_lock_t *locking) {
+  tealet_sub_t *tealet = (tealet_sub_t *)_tealet;
+  tealet_main_t *g_main = TEALET_GET_MAIN(tealet);
+
+  if (locking == NULL) {
+    g_main->g_locking.lock = NULL;
+    g_main->g_locking.unlock = NULL;
+    g_main->g_locking.arg = NULL;
+  } else {
+    g_main->g_locking = *locking;
+  }
+  return 0;
+}
+
 /* Convenience API to enable stack checking with practical defaults.
  *
  * - Enables integrity + guard + snapshot flags.
@@ -2010,6 +2028,18 @@ void *tealet_malloc(tealet_t *tealet, size_t s) {
 void tealet_free(tealet_t *tealet, void *p) {
   tealet_main_t *g_main = TEALET_GET_MAIN(tealet);
   tealet_int_free(g_main, p);
+}
+
+void tealet_lock(tealet_t *tealet) {
+  tealet_main_t *g_main = TEALET_GET_MAIN(tealet);
+  if (g_main->g_locking.lock)
+    g_main->g_locking.lock(g_main->g_locking.arg);
+}
+
+void tealet_unlock(tealet_t *tealet) {
+  tealet_main_t *g_main = TEALET_GET_MAIN(tealet);
+  if (g_main->g_locking.unlock)
+    g_main->g_locking.unlock(g_main->g_locking.arg);
 }
 
 ptrdiff_t tealet_stack_diff(void *a, void *b) { return STACKMAN_SP_DIFF((ptrdiff_t)a, (ptrdiff_t)(b)); }

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -60,6 +60,7 @@
 
 /* a chunk represents a single segment of saved stack */
 typedef struct tealet_chunk_t {
+  int refcount;                /* controls chunk lifetime */
   struct tealet_chunk_t *next; /* additional chunks */
   char *stack_near;            /* near stack address */
   size_t size;                 /* amount of data saved */
@@ -79,6 +80,7 @@ typedef struct tealet_stack_t {
   char *stack_far;              /* the far boundary of this stack (or STACKMAN_SP_FURTHEST
                                    for unbounded) */
   size_t saved;                 /* total amount of memory saved in all chunks */
+  struct tealet_chunk_t *last;  /* last chunk in the chain */
   struct tealet_chunk_t chunk;  /* the initial chunk */
 } tealet_stack_t;
 
@@ -235,6 +237,30 @@ static void *tealet_int_malloc(tealet_main_t *main, size_t size) {
 }
 static void tealet_int_free(tealet_main_t *main, void *ptr) { main->g_alloc.free_p(ptr, main->g_alloc.context); }
 
+/* Debug-only sanity check that caller stack plausibly matches current tealet.
+ *
+ * This is intentionally best-effort: we do not know the full virtual-memory
+ * extent for the current stack slice, so for bounded stacks we can only check
+ * ordering against current->stack_far. That catches some foreign-thread calls,
+ * but not all of them.
+ */
+static void tealet_verify_current_matches_caller(tealet_sub_t *current) {
+#ifndef NDEBUG
+  char stack_probe = 0;
+  char *sp = &stack_probe;
+
+  assert(current != NULL);
+  assert((current->flags & TEALET_TFLAGS_EXITED) == 0);
+
+  if (current->stack_far != STACKMAN_SP_FURTHEST) {
+    assert(current->stack_far != NULL);
+    assert(STACKMAN_SP_LS(sp, current->stack_far));
+  }
+#else
+  (void)current;
+#endif
+}
+
 /* ----------------------------------------------------------------
  * Stack integrity helpers (snapshot + guard planning).
  */
@@ -318,6 +344,7 @@ static void tealet_integrity_plan_for_current(tealet_main_t *g_main) {
   tealet_integrity_data_clear(plan);
 
   current = g_main->g_current;
+  tealet_verify_current_matches_caller(current);
   assert(current != NULL);
 
   if (current->stack_far == STACKMAN_SP_FURTHEST)
@@ -559,6 +586,8 @@ static void tealet_snapshot_capture_current(tealet_main_t *g_main) {
   char *stack_base = g_main->g_integrity_data.stack_base;
   size_t size = g_main->g_integrity_data.snapshot_bytes;
 
+  tealet_verify_current_matches_caller(current);
+
   if (size == 0)
     return;
 
@@ -752,8 +781,10 @@ static tealet_stack_t *tealet_stack_new(tealet_main_t *main, char *stack_near, c
   s->stack_far = stack_far;
   s->flags = 0;
   s->saved = size;
+  s->last = &s->chunk;
 
   s->chunk.next = NULL;
+  s->chunk.refcount = 1;
   s->chunk.stack_near = stack_near;
   s->chunk.size = size;
 #if STACK_DIRECTION == 0
@@ -779,6 +810,7 @@ static int tealet_stack_grow(tealet_main_t *main, tealet_stack_t *stack, size_t 
   main->g_stack_chunk_count++; /* Additional chunk */
   main->g_stack_bytes += tsize;
 #endif
+  chunk->refcount = 1;
 #if STACK_DIRECTION == 0
   chunk->stack_near = stack->chunk.stack_near + stack->saved;
   memcpy(&chunk->data[0], chunk->stack_near, diff);
@@ -787,8 +819,10 @@ static int tealet_stack_grow(tealet_main_t *main, tealet_stack_t *stack, size_t 
   memcpy(&chunk->data[0], chunk->stack_near - diff, diff);
 #endif
   chunk->size = diff;
-  chunk->next = stack->chunk.next;
-  stack->chunk.next = chunk;
+  chunk->next = NULL;
+  assert(stack->last != NULL);
+  stack->last->next = chunk;
+  stack->last = chunk;
   stack->saved = size;
   return 0;
 }
@@ -835,6 +869,27 @@ static void tealet_stack_unlink(tealet_stack_t *stack) {
   stack->prev = NULL;
 }
 
+static void tealet_chunk_decref(tealet_main_t *main, tealet_chunk_t *chunk) {
+  while (chunk != NULL) {
+    tealet_chunk_t *next;
+
+    if (--chunk->refcount > 0)
+      return;
+
+    /* Only release the remainder of the chain if this node was actually
+     * released. Shared nodes keep ownership of their successors.
+     */
+    next = chunk->next;
+    STATS_SUB_ALLOC(main, offsetof(tealet_chunk_t, data[0]) + chunk->size);
+#if TEALET_WITH_STATS
+    main->g_stack_chunk_count--; /* Additional chunk */
+    main->g_stack_bytes -= offsetof(tealet_chunk_t, data[0]) + chunk->size;
+#endif
+    tealet_int_free(main, (void *)chunk);
+    chunk = next;
+  }
+}
+
 static void tealet_stack_decref(tealet_main_t *main, tealet_stack_t *stack) {
   tealet_chunk_t *chunk;
   if (stack == NULL || --stack->refcount > 0)
@@ -850,16 +905,8 @@ static void tealet_stack_decref(tealet_main_t *main, tealet_stack_t *stack) {
   main->g_stack_bytes -= offsetof(tealet_stack_t, chunk.data[0]) + stack->chunk.size;
 #endif
   tealet_int_free(main, (void *)stack);
-  while (chunk) {
-    tealet_chunk_t *next = chunk->next;
-    STATS_SUB_ALLOC(main, offsetof(tealet_chunk_t, data[0]) + chunk->size);
-#if TEALET_WITH_STATS
-    main->g_stack_chunk_count--; /* Additional chunk */
-    main->g_stack_bytes -= offsetof(tealet_chunk_t, data[0]) + chunk->size;
-#endif
-    tealet_int_free(main, (void *)chunk);
-    chunk = next;
-  }
+  if (chunk != NULL)
+    tealet_chunk_decref(main, chunk);
 }
 
 static void tealet_stack_defunct(tealet_main_t *main, tealet_stack_t *stack) {
@@ -868,18 +915,11 @@ static void tealet_stack_defunct(tealet_main_t *main, tealet_stack_t *stack) {
   tealet_chunk_t *chunk;
   chunk = stack->chunk.next;
   stack->chunk.next = NULL;
+  stack->last = &stack->chunk;
   stack->flags |= TEALET_SFLAGS_DEFUNCT;
   stack->saved = 0;
-  while (chunk) {
-    tealet_chunk_t *next = chunk->next;
-    STATS_SUB_ALLOC(main, offsetof(tealet_chunk_t, data[0]) + chunk->size);
-#if TEALET_WITH_STATS
-    main->g_stack_chunk_count--; /* Additional chunk being made defunct */
-    main->g_stack_bytes -= offsetof(tealet_chunk_t, data[0]) + chunk->size;
-#endif
-    tealet_int_free(main, (void *)chunk);
-    chunk = next;
-  }
+  if (chunk != NULL)
+    tealet_chunk_decref(main, chunk);
 }
 
 static int tealet_is_defunct(tealet_sub_t *tealet) {
@@ -1021,6 +1061,9 @@ static int tealet_save_state(tealet_main_t *g_main, void *old_stack_pointer) {
   tealet_sub_t *g_current = g_main->g_current;
   char *target_stop = g_target->stack_far;
   int exiting, fail, fail_ok, auto_delete;
+
+  tealet_verify_current_matches_caller(g_current);
+
   assert((g_target->flags & TEALET_TFLAGS_EXITED) == 0); /* target isn't exiting */
   assert(g_current != g_target);
 
@@ -1164,6 +1207,7 @@ static int tealet_check_caller_is_current(tealet_sub_t *g_current) {
 
   assert(g_current != NULL);
   assert((g_current->flags & TEALET_TFLAGS_EXITED) == 0);
+  tealet_verify_current_matches_caller(g_current);
 
   g_main = TEALET_GET_MAIN(g_current);
   max_stack_size = g_main->g_cfg_max_stack_size;
@@ -1201,8 +1245,13 @@ static int tealet_switchstack(tealet_main_t *g_main, tealet_sub_t *target, void 
   assert(target);
   assert(target != g_main->g_current);
 
-  if (target->flags & TEALET_TFLAGS_EXITED)
+  /* Locking is owned by top-level switching APIs (new/create/switch/exit/fork).
+   * This helper assumes the caller already established the desired lock scope.
+   */
+
+  if (target->flags & TEALET_TFLAGS_EXITED) {
     return TEALET_ERR_INVAL;
+  }
 
   /* if the target saved stack is invalid (due to a failure to save it
    * during the exit of another tealet), we detect this here and
@@ -1213,22 +1262,26 @@ static int tealet_switchstack(tealet_main_t *g_main, tealet_sub_t *target, void 
    * -1 = error, couldn't save state
    * -2 = error, target tealet corrupt
    */
-  if (tealet_is_defunct(target))
+  if (tealet_is_defunct(target)) {
     return TEALET_ERR_DEFUNCT;
+  }
 
   err_result = tealet_check_caller_is_current(g_main->g_current);
-  if (err_result)
+  if (err_result) {
     return err_result;
+  }
 
   tealet_guard_unprotect_current(g_main);
 
   err_result = tealet_snapshot_verify_current(g_main);
   if (err_result)
-    /* Intentional behavior: on integrity error we return without re-arming
-     * current guard/snapshot state. This is a best-effort mode that favors
-     * continued execution after reporting the error.
-     */
+  /* Intentional behavior: on integrity error we return without re-arming
+   * current guard/snapshot state. This is a best-effort mode that favors
+   * continued execution after reporting the error.
+   */
+  {
     return err_result;
+  }
 
   g_main->g_previous = g_main->g_current;
   g_main->g_target = target;
@@ -1287,6 +1340,7 @@ static int tealet_switchstack(tealet_main_t *g_main, tealet_sub_t *target, void 
  * stack_far is the far end of this stack and must be
  * far enough that local variables in this function get saved.
  * A stack variable in the calling function is sufficient.
+ * The lock is held on entry.
  */
 static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet_sub_t *g_target, tealet_run_t run,
                               void **parg, void *stack_far) {
@@ -1344,7 +1398,10 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
     }
     assert(g_main->g_current->stack == NULL); /* running */
 
+    /* release the lock and run the tealet */
+    tealet_unlock((tealet_t *)g_main);
     g_exit_target = (tealet_sub_t *)(run((tealet_t *)g_main->g_current, run_arg));
+
     tealet_exit((tealet_t *)g_exit_target, NULL, TEALET_EXIT_DELETE);
     assert(!"This point should not be reached");
   } else {
@@ -1410,9 +1467,11 @@ static tealet_sub_t *tealet_alloc(tealet_main_t *g_main) {
   tealet_sub_t *result;
   size_t basesize = offsetof(tealet_nonmain_t, _extra);
   size_t extrasize = g_main->g_extrasize;
+
   result = tealet_alloc_raw(g_main, &g_main->g_alloc, basesize, extrasize);
 #if TEALET_WITH_STATS
-  g_main->g_tealets++;
+  if (result != NULL)
+    g_main->g_tealets++;
 #endif
   return result;
 }
@@ -1497,6 +1556,11 @@ static void *tealet_pick_initial_far(void *default_far, void *hint) {
 
 /* create a tealet by saving the current stack and starting
  * immediate execution of a new one
+ *
+ * Switching API lock policy:
+ * all five switching APIs (`tealet_new()`, `tealet_create()`,
+ * `tealet_switch()`, `tealet_exit()`, `tealet_fork()`) acquire/release
+ * the lock internally.
  */
 tealet_t *tealet_new(tealet_t *tealet, tealet_run_t run, void **parg, void *stack_far) {
   tealet_sub_t *result; /* store this until we return */
@@ -1505,24 +1569,33 @@ tealet_t *tealet_new(tealet_t *tealet, tealet_run_t run, void **parg, void *stac
   void *default_far;
   void *stack_far_used;
   tealet_main_t *g_main = TEALET_GET_MAIN(tealet);
+  tealet_lock((tealet_t *)g_main);
   assert(!g_main->g_target);
   result = tealet_alloc(g_main);
-  if (result == NULL)
-    return NULL; /* Could not allocate */
+  if (result == NULL) {
+    goto done; /* Could not allocate */
+  }
   default_far = (void *)&result;
   stack_far_used = tealet_pick_initial_far(default_far, stack_far);
   fail = tealet_initialstub(g_main, result, result, run, (parg != NULL ? parg : &arg), stack_far_used);
   if (fail) {
     /* could not save stack */
     tealet_delete((tealet_t *)result);
-    return NULL;
+    result = NULL;
   }
+done:
+  tealet_unlock((tealet_t *)g_main);
   return (tealet_t *)result;
 }
 
 /* create a tealet by saving the target stack and switching
  * back to the caller, allowing the caller to run the
  * tealet proper later, by switching to it.
+ *
+ * Switching API lock policy:
+ * all five switching APIs (`tealet_new()`, `tealet_create()`,
+ * `tealet_switch()`, `tealet_exit()`, `tealet_fork()`) acquire/release
+ * the lock internally.
  */
 tealet_t *tealet_create(tealet_t *tealet, tealet_run_t run, void *stack_far) {
   tealet_sub_t *result; /* store this until we return */
@@ -1530,12 +1603,17 @@ tealet_t *tealet_create(tealet_t *tealet, tealet_run_t run, void *stack_far) {
   void *default_far;
   void *stack_far_used;
   tealet_main_t *g_main = TEALET_GET_MAIN(tealet);
-  tealet_sub_t *previous = g_main->g_previous;
-  tealet_sub_t *current = g_main->g_current;
+  tealet_sub_t *previous;
+  tealet_sub_t *current;
+
+  tealet_lock((tealet_t *)g_main);
+  previous = g_main->g_previous;
+  current = g_main->g_current;
+  tealet_verify_current_matches_caller(current);
   assert(!g_main->g_target);
   result = tealet_alloc(g_main);
   if (result == NULL)
-    return NULL; /* Could not allocate */
+    goto done; /* Could not allocate */
   /* we turn into the new tealet and switch back, in order
    * to save the new tealet's stack at this position
    */
@@ -1547,7 +1625,7 @@ tealet_t *tealet_create(tealet_t *tealet, tealet_run_t run, void *stack_far) {
     /* could not save stack */
     tealet_delete((tealet_t *)result);
     g_main->g_current = current;
-    return NULL;
+    result = NULL;
   } else {
     /* restore g_previous to whatever it was.  We don't count
      * this switch from the temporary tealet back to us
@@ -1555,17 +1633,36 @@ tealet_t *tealet_create(tealet_t *tealet, tealet_run_t run, void *stack_far) {
      */
     g_main->g_previous = previous;
   }
+done:
+  tealet_unlock((tealet_t *)g_main);
   return (tealet_t *)result;
 }
 
+/* Switch to a tealet and back.
+ *
+ * Switching API lock policy:
+ * all five switching APIs (`tealet_new()`, `tealet_create()`,
+ * `tealet_switch()`, `tealet_exit()`, `tealet_fork()`) acquire/release
+ * the lock internally.
+ */
+
 int tealet_switch(tealet_t *stub, void **parg) {
   tealet_sub_t *g_target = (tealet_sub_t *)stub;
+  tealet_sub_t *g_current;
+  int result;
   tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
-  if (g_target == g_main->g_current) {
-    g_main->g_previous = g_main->g_current;
-    return 0; /* switch to self */
+
+  tealet_lock((tealet_t *)g_main);
+  g_current = g_main->g_current;
+  tealet_verify_current_matches_caller(g_current);
+  if (g_target == g_current) {
+    g_main->g_previous = g_current;
+    result = 0; /* switch to self */
+  } else {
+    result = tealet_switchstack(g_main, g_target, parg ? *parg : NULL, parg);
   }
-  return tealet_switchstack(g_main, g_target, parg ? *parg : NULL, parg);
+  tealet_unlock((tealet_t *)g_main);
+  return result;
 }
 
 static int tealet_exit_inner(tealet_t *target, void *arg, int flags) {
@@ -1574,6 +1671,9 @@ static int tealet_exit_inner(tealet_t *target, void *arg, int flags) {
   tealet_sub_t *g_current = g_main->g_current;
   char *stack_far = g_target->stack_far;
   int result;
+
+  tealet_verify_current_matches_caller(g_current);
+
   assert(g_current != (tealet_sub_t *)g_main); /* mustn't exit main */
   if (g_target == g_current)
     return -2; /* invalid tealet */
@@ -1591,10 +1691,20 @@ static int tealet_exit_inner(tealet_t *target, void *arg, int flags) {
   return result;
 }
 
+/* Exit current tealet and transfer control.
+ *
+ * Switching API lock policy:
+ * all five switching APIs (`tealet_new()`, `tealet_create()`,
+ * `tealet_switch()`, `tealet_exit()`, `tealet_fork()`) acquire/release
+ * the lock internally.
+ */
+
 int tealet_exit(tealet_t *target, void *arg, int flags) {
   tealet_sub_t *g_target = (tealet_sub_t *)target;
   tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
   int result;
+
+  tealet_lock((tealet_t *)g_main);
   if (flags & TEALET_EXIT_DEFER) {
     /* setting up arg and flags for the run() return value */
     /* We temporarily borrow g_flags/g_arg storage on main until the
@@ -1603,7 +1713,8 @@ int tealet_exit(tealet_t *target, void *arg, int flags) {
     assert(g_main->g_flags == 0);
     g_main->g_arg = arg;
     g_main->g_flags = flags;
-    return 0;
+    tealet_unlock((tealet_t *)g_main);
+    return 0; /* deferred exit, we are done here */
   }
   if (g_main->g_flags & TEALET_EXIT_DEFER) {
     /* Called second time (e.g. from return of run())
@@ -1620,32 +1731,52 @@ int tealet_exit(tealet_t *target, void *arg, int flags) {
     g_main->g_flags |= TEALET_MFLAGS_PANIC;
   /* fallback: switch to main */
   result = tealet_exit_inner(target->main, arg, flags);
-  /* should never reach here */
-  assert(0);
-  return result;
+  (void)result;
+  /* Unreachable in normal operation: successful tealet_exit_inner() does not
+   * return to this frame. If control returns here, execution state is corrupt.
+   */
+  assert(0 && "unreachable tealet_exit return path");
+  abort();
 }
+
+/* Fork the active tealet.
+ *
+ * Switching API lock policy:
+ * all five switching APIs (`tealet_new()`, `tealet_create()`,
+ * `tealet_switch()`, `tealet_exit()`, `tealet_fork()`) acquire/release
+ * the lock internally.
+ */
 
 int tealet_fork(tealet_t *_tealet, tealet_t **pother, void **parg, int flags) {
   tealet_sub_t *tealet = (tealet_sub_t *)_tealet;
   tealet_main_t *g_main = TEALET_GET_MAIN(tealet);
-  tealet_sub_t *g_current = g_main->g_current;
+  tealet_sub_t *g_current;
   tealet_sub_t *previous;
   tealet_sub_t *g_child;
   int result, is_parent;
+  int api_result;
+
+  tealet_lock((tealet_t *)g_main);
+  g_current = g_main->g_current;
+  tealet_verify_current_matches_caller(g_current);
 
   /* Current tealet must have a bounded stack (far boundary set).
    * Even the main tealet can fork if its far boundary has been set.
    */
-  if (TEALET_STACK_IS_UNBOUNDED(g_current))
-    return TEALET_ERR_UNFORKABLE;
+  if (TEALET_STACK_IS_UNBOUNDED(g_current)) {
+    api_result = TEALET_ERR_UNFORKABLE;
+    goto done;
+  }
 
   /* Active tealets have NULL stack (implied by the check above) */
   assert(g_current->stack == NULL);
 
   /* Allocate the child tealet */
   g_child = tealet_alloc(g_main);
-  if (g_child == NULL)
-    return TEALET_ERR_MEM;
+  if (g_child == NULL) {
+    api_result = TEALET_ERR_MEM;
+    goto done;
+  }
 
   /* Copy extra data if present */
   if (g_main->g_extrasize)
@@ -1684,18 +1815,28 @@ int tealet_fork(tealet_t *_tealet, tealet_t **pother, void **parg, int flags) {
   if (result < 0) {
     /* Failed to save stack */
     tealet_free_tealet(g_main, g_child);
-    return TEALET_ERR_MEM;
+    api_result = TEALET_ERR_MEM;
+    goto done;
   }
 
   if (pother)
     *pother = (tealet_t *)(is_parent ? g_child : g_current);
-  return is_parent;
+  api_result = is_parent;
+
+done:
+  /* we are now back.  If successful, we are either conceptually the same stack as when we called,
+   * or we have been switched to (via tealet_switch or tealet_exit().  in either case,
+   * release the lock.
+   */
+  tealet_unlock((tealet_t *)g_main);
+  return api_result;
 }
 
 tealet_t *tealet_duplicate(tealet_t *tealet) {
   tealet_sub_t *g_tealet = (tealet_sub_t *)tealet;
   tealet_main_t *g_main = TEALET_GET_MAIN(g_tealet);
   tealet_sub_t *g_copy;
+
   /* can't dup the current or the main tealet */
   assert(g_tealet != g_main->g_current && g_tealet != (tealet_sub_t *)g_main);
   g_copy = tealet_alloc(g_main);
@@ -1715,10 +1856,10 @@ void tealet_delete(tealet_t *target) {
   tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
   assert(!TEALET_IS_MAIN(target));
   tealet_stack_decref(g_main, g_target->stack);
-  tealet_free_tealet(g_main, g_target);
 #if TEALET_WITH_STATS
   g_main->g_tealets--;
 #endif
+  tealet_free_tealet(g_main, g_target);
 }
 
 /* ----------------------------------------------------------------

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -34,6 +34,12 @@
 /** A structure to define the memory allocation api used.
  * the functions have C89 semantics and take an additional "context"
  * pointer that they can use as they please
+ *
+ * Threading contract with optional tealet locking:
+ * allocator callbacks may be invoked either with or without the configured
+ * tealet lock held. Integrations must not rely on tealet_lock() for allocator
+ * protection, and allocator implementations must avoid deadlocking in either
+ * call context.
  */
 typedef void *(*tealet_malloc_t)(size_t size, void *context);
 typedef void (*tealet_free_t)(void *ptr, void *context);
@@ -42,6 +48,17 @@ typedef struct tealet_alloc_t {
   tealet_free_t free_p;
   void *context;
 } tealet_alloc_t;
+
+/** Optional locking hooks for thread-safe tealet-structure access.
+ *
+ * The callbacks are invoked by tealet_lock()/tealet_unlock() with @p arg.
+ * If either callback is NULL, the corresponding API becomes a no-op.
+ */
+typedef struct tealet_lock_t {
+  void (*lock)(void *arg);
+  void (*unlock)(void *arg);
+  void *arg;
+} tealet_lock_t;
 
 /** use the following macro to initialize a tealet_alloc_t
  * structure with stdlib malloc functions, for convenience, e.g.:
@@ -557,6 +574,22 @@ TEALET_API
 int tealet_configure_set(tealet_t *tealet, tealet_config_t *config);
 
 /**
+ * @brief Configure optional locking callbacks for a main-tealet domain.
+ * @param tealet Any tealet in the domain.
+ * @param locking Lock callback descriptor to copy; pass NULL to clear (no-op mode).
+ * @return 0 on success.
+ *
+ * This stores callback pointers and argument on the domain's main tealet.
+ * It does not acquire or release locks itself.
+ *
+ * Locking/allocator interaction contract: libtealet may call allocator
+ * callbacks with or without this lock held, depending on call path.
+ * Do not assume either state.
+ */
+TEALET_API
+int tealet_config_set_locking(tealet_t *tealet, const tealet_lock_t *locking);
+
+/**
  * @brief Enable stack-integrity checking with practical defaults.
  * @param tealet Any tealet in the domain.
  * @param stack_integrity_bytes Requested watch window bytes; 0 picks sensible default.
@@ -609,6 +642,24 @@ void *tealet_malloc(tealet_t *tealet, size_t s);
  */
 TEALET_API
 void tealet_free(tealet_t *tealet, void *p);
+
+/**
+ * @brief Invoke configured lock callback for this tealet domain.
+ * @param tealet Any tealet in the domain.
+ *
+ * No-op when no lock callback is configured.
+ */
+TEALET_API
+void tealet_lock(tealet_t *tealet);
+
+/**
+ * @brief Invoke configured unlock callback for this tealet domain.
+ * @param tealet Any tealet in the domain.
+ *
+ * No-op when no unlock callback is configured.
+ */
+TEALET_API
+void tealet_unlock(tealet_t *tealet);
 
 /* functions for stack arithmetic.  Useful when deciding
  * if you want to start a new tealet, or when doing stack

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -53,6 +53,10 @@ typedef struct tealet_alloc_t {
  *
  * The callbacks are invoked by tealet_lock()/tealet_unlock() with @p arg.
  * If either callback is NULL, the corresponding API becomes a no-op.
+ *
+ * Primary multi-threaded use case: coordinating foreign-thread
+ * tealet_delete() of non-main tealets. Configuration, switching, and
+ * tealet_duplicate() are intended to remain on one owning thread.
  */
 typedef struct tealet_lock_t {
   void (*lock)(void *arg);
@@ -394,6 +398,11 @@ tealet_t *tealet_current(tealet_t *tealet);
 /** Return the previous tealet, i.e. the one that switched to us.
  * "tealet" can be any tealet derived from the
  * main tealet.
+ *
+ * Note: in a multithreaded setting, a previous tealet can be simultaneously
+ * deleted by a different thread, invalidating the returned pointer.
+ * Query APIs are permitted from foreign threads, but they do not guarantee
+ * a globally consistent snapshot of tealet state.
  */
 TEALET_API
 tealet_t *tealet_previous(tealet_t *tealet);
@@ -581,6 +590,8 @@ int tealet_configure_set(tealet_t *tealet, tealet_config_t *config);
  *
  * This stores callback pointers and argument on the domain's main tealet.
  * It does not acquire or release locks itself.
+ * Configuration, switching, and tealet_duplicate() remain single-thread
+ * responsibilities.
  *
  * Locking/allocator interaction contract: libtealet may call allocator
  * callbacks with or without this lock held, depending on call path.

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -54,9 +54,9 @@ typedef struct tealet_alloc_t {
  * The callbacks are invoked by tealet_lock()/tealet_unlock() with @p arg.
  * If either callback is NULL, the corresponding API becomes a no-op.
  *
- * Primary multi-threaded use case: coordinating foreign-thread
- * tealet_delete() of non-main tealets. Configuration, switching, and
- * tealet_duplicate() are intended to remain on one owning thread.
+ * Primary multi-threaded use case: coordinating foreign-thread structure
+ * operations (for example tealet_delete() and tealet_duplicate()) on
+ * non-main tealets with explicit external synchronization.
  */
 typedef struct tealet_lock_t {
   void (*lock)(void *arg);
@@ -593,8 +593,8 @@ int tealet_configure_set(tealet_t *tealet, tealet_config_t *config);
  *
  * This stores callback pointers and argument on the domain's main tealet.
  * It does not acquire or release locks itself.
- * Configuration, switching, and tealet_duplicate() remain single-thread
- * responsibilities.
+ * Configuration and non-switch structure APIs can be called from any thread
+ * when callers provide synchronization. Switching remains thread-affine.
  *
  * Locking/allocator interaction contract: libtealet may call allocator
  * callbacks with or without this lock held, depending on call path.

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -399,10 +399,13 @@ tealet_t *tealet_current(tealet_t *tealet);
  * "tealet" can be any tealet derived from the
  * main tealet.
  *
+ * Query APIs in this section are not internally synchronized. If they are
+ * called from foreign threads, or concurrently with lifecycle/switching
+ * operations, callers must provide external synchronization (for example
+ * tealet_lock()/tealet_unlock() around the entire access sequence).
+ *
  * Note: in a multithreaded setting, a previous tealet can be simultaneously
  * deleted by a different thread, invalidating the returned pointer.
- * Query APIs are permitted from foreign threads, but they do not guarantee
- * a globally consistent snapshot of tealet state.
  */
 TEALET_API
 tealet_t *tealet_previous(tealet_t *tealet);

--- a/tests/setcontext.c
+++ b/tests/setcontext.c
@@ -6,9 +6,12 @@
 
 #include "tealet.h"
 #include "tealet_extras.h"
+#include "test_lock_helpers.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+static tealet_test_lock_state_t g_lock_state;
 
 /* This is the iterator function. It is entered on the first call to
  * swapcontext, and loops from 0 to 9. Each value is saved in i_from_iterator,
@@ -19,12 +22,15 @@
 tealet_t *loop_func(tealet_t *current, void *arg) {
   int i;
 
+  tealet_test_lock_assert_unheld(&g_lock_state);
+
   for (i = 0; i < (int)(intptr_t)arg; ++i) {
     /* Write the loop counter a variable used for passing between tealets. */
     void *value = (void *)(intptr_t)i;
 
     /* Switch to main tealet */
     tealet_switch(tealet_previous(current), &value);
+    tealet_test_lock_assert_unheld(&g_lock_state);
     /* after switch, any void* passed _to_ us is in 'value' */
   }
   /* exit, without deleting, so that the caller can query status */
@@ -43,8 +49,11 @@ int main(void) {
   if (tmain == NULL)
     return 1;
 
+  tealet_test_lock_install(tmain, &g_lock_state);
+
   configure_result = tealet_configure_check_stack(tmain, 0);
   if (configure_result != 0) {
+    tealet_test_lock_assert_balanced(&g_lock_state);
     tealet_finalize(tmain);
     return 1;
   }
@@ -62,6 +71,7 @@ int main(void) {
     tealet_switch(loop, &data);
   }
   tealet_delete(loop);
+  tealet_test_lock_assert_balanced(&g_lock_state);
   tealet_finalize(tmain);
   return 0;
 }

--- a/tests/test_chunks.c
+++ b/tests/test_chunks.c
@@ -8,11 +8,13 @@
  * - Statistics properly track multiple chunks
  */
 #include "tealet.h"
+#include "test_lock_helpers.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
 static tealet_t *g_main = NULL;
+static tealet_test_lock_state_t g_lock_state;
 
 /* Helper to recurse and consume stack space - NOT tail-recursive */
 static void consume_stack(int depth, char *buffer) {
@@ -33,12 +35,17 @@ static tealet_t *worker_run(tealet_t *t, void *arg) {
   char buffer[100];
   int depth = (int)(intptr_t)arg;
 
+  (void)t;
+  tealet_test_lock_assert_unheld(&g_lock_state);
+
   /* Consume stack based on depth parameter */
   if (depth > 0)
     consume_stack(depth, buffer);
 
   /* Yield back to main */
   tealet_switch(g_main, NULL);
+
+  tealet_test_lock_assert_unheld(&g_lock_state);
 
   return g_main;
 }
@@ -54,9 +61,11 @@ int main(void) {
     fprintf(stderr, "Failed to initialize\n");
     return 1;
   }
+  tealet_test_lock_install(g_main, &g_lock_state);
   configure_result = tealet_configure_check_stack(g_main, 0);
   if (configure_result != 0) {
     fprintf(stderr, "Failed to enable stack checks: %d\n", configure_result);
+    tealet_test_lock_assert_balanced(&g_lock_state);
     tealet_finalize(g_main);
     return 1;
   }
@@ -68,6 +77,7 @@ int main(void) {
   t1 = tealet_new(g_main, worker_run, NULL, NULL);
   if (!t1) {
     fprintf(stderr, "Failed to create tealet\n");
+    tealet_test_lock_assert_balanced(&g_lock_state);
     tealet_finalize(g_main);
     return 1;
   }
@@ -96,6 +106,7 @@ int main(void) {
   if (!t2) {
     fprintf(stderr, "Failed to duplicate tealet\n");
     tealet_delete(t1);
+    tealet_test_lock_assert_balanced(&g_lock_state);
     tealet_finalize(g_main);
     return 1;
   }
@@ -114,6 +125,7 @@ int main(void) {
     fprintf(stderr, "Failed to duplicate tealet\n");
     tealet_delete(t1);
     tealet_delete(t2);
+    tealet_test_lock_assert_balanced(&g_lock_state);
     tealet_finalize(g_main);
     return 1;
   }
@@ -136,6 +148,7 @@ int main(void) {
   tealet_delete(t3);
   tealet_delete(t2);
   tealet_delete(t1);
+  tealet_test_lock_assert_balanced(&g_lock_state);
   tealet_finalize(g_main);
 
   printf("\n=== Test completed successfully ===\n");

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -14,9 +14,16 @@
 #endif
 
 #include "tealet.h"
+#include "test_lock_helpers.h"
 
 static int test_count = 0;
 static int test_passed = 0;
+static tealet_test_lock_state_t g_lock_state;
+
+static void finalize_main_checked(tealet_t *main_tealet) {
+  tealet_test_lock_assert_balanced(&g_lock_state);
+  tealet_finalize(main_tealet);
+}
 
 /*
  * Runtime outcomes for alignment-sensitive mprotect split tests.
@@ -48,6 +55,7 @@ static tealet_t *new_main_plain(void) {
 
   main_tealet = tealet_initialize(&alloc, 0);
   assert(main_tealet != NULL);
+  tealet_test_lock_install(main_tealet, &g_lock_state);
   return main_tealet;
 }
 
@@ -92,6 +100,8 @@ static tealet_t *run_write_to_target(tealet_t *current, void *arg) {
   void *far;
   int switch_result;
 
+  tealet_test_lock_assert_unheld(&g_lock_state);
+
   if (command->write_inside) {
     far = tealet_get_far(current);
     assert(far != NULL);
@@ -126,6 +136,8 @@ static tealet_t *run_resize_snapshot_while_active(tealet_t *current, void *arg) 
 #if TEALET_WITH_STACK_SNAPSHOT
   resize_snapshot_command_t *command = (resize_snapshot_command_t *)arg;
   tealet_config_t cfg = TEALET_CONFIG_INIT;
+
+  tealet_test_lock_assert_unheld(&g_lock_state);
 
   cfg.flags = TEALET_CONFIGF_STACK_INTEGRITY | TEALET_CONFIGF_STACK_SNAPSHOT;
   cfg.stack_integrity_bytes = 4096;
@@ -177,6 +189,8 @@ static tealet_t *run_write_with_mprotect_split(tealet_t *current, void *arg) {
   int snapshot_has_bytes;
   unsigned char sp_probe;
   uintptr_t current_sp;
+
+  tealet_test_lock_assert_unheld(&g_lock_state);
 
   page_size = (size_t)sysconf(_SC_PAGESIZE);
   assert(page_size > 0);
@@ -317,7 +331,7 @@ static int run_integrity_switch_case(int fail_policy, int write_inside, int *fir
   assert(result == 0);
   tealet_free(main_tealet, outside_target);
   tealet_free(main_tealet, command);
-  tealet_finalize(main_tealet);
+  finalize_main_checked(main_tealet);
 
   if (first_result)
     *first_result = first_switch_result;
@@ -384,13 +398,13 @@ static int run_mprotect_split_case(int write_guard_page, int *first_result, int 
     if (recovery_result)
       *recovery_result = second_switch_result;
     tealet_free(main_tealet, command);
-    tealet_finalize(main_tealet);
+    finalize_main_checked(main_tealet);
     return result;
   }
 
   assert(result == 0);
   tealet_free(main_tealet, command);
-  tealet_finalize(main_tealet);
+  finalize_main_checked(main_tealet);
 
   if (first_result)
     *first_result = first_switch_result;
@@ -426,7 +440,7 @@ static void test_get_defaults(void) {
   assert(cfg.stack_integrity_fail_policy == TEALET_STACK_INTEGRITY_FAIL_ASSERT);
   assert(cfg.stack_guard_limit == NULL);
 
-  tealet_finalize(main_tealet);
+  finalize_main_checked(main_tealet);
   PASS();
 }
 
@@ -480,7 +494,7 @@ static void test_set_canonicalizes_unsupported(void) {
   assert(get_cfg.stack_guard_mode == set_cfg.stack_guard_mode);
   assert(get_cfg.stack_guard_limit == NULL);
 
-  tealet_finalize(main_tealet);
+  finalize_main_checked(main_tealet);
   PASS();
 }
 
@@ -504,7 +518,7 @@ static void test_set_snapshot_supported_build(void) {
   assert((cfg.flags & TEALET_CONFIGF_STACK_INTEGRITY) != 0);
   assert(cfg.stack_integrity_bytes == 2048);
 
-  tealet_finalize(main_tealet);
+  finalize_main_checked(main_tealet);
   PASS();
 #endif
 }
@@ -583,7 +597,7 @@ static void test_set_while_snapshot_active_resizes(void) {
   assert(get_cfg.stack_integrity_bytes == 4096);
 
   tealet_free(main_tealet, command);
-  tealet_finalize(main_tealet);
+  finalize_main_checked(main_tealet);
   PASS();
 #endif
 }
@@ -787,7 +801,7 @@ static void test_set_invalid_version(void) {
   result = tealet_configure_set(main_tealet, &cfg);
   assert(result == TEALET_ERR_INVAL);
 
-  tealet_finalize(main_tealet);
+  finalize_main_checked(main_tealet);
   PASS();
 }
 
@@ -809,7 +823,7 @@ static void test_header_size_validation(void) {
   result = tealet_configure_set(main_tealet, &cfg);
   assert(result == TEALET_ERR_INVAL);
 
-  tealet_finalize(main_tealet);
+  finalize_main_checked(main_tealet);
   PASS();
 }
 

--- a/tests/test_fork.c
+++ b/tests/test_fork.c
@@ -1,6 +1,7 @@
 /* Test tealet_fork functionality */
 
 #include "tealet.h"
+#include "test_lock_helpers.h"
 #include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -8,6 +9,12 @@
 
 static int test_count = 0;
 static int test_passed = 0;
+static tealet_test_lock_state_t g_lock_state;
+
+static void finalize_main_checked(tealet_t *main) {
+  tealet_test_lock_assert_balanced(&g_lock_state);
+  tealet_finalize(main);
+}
 
 static void assert_origin_main(tealet_t *t) {
   unsigned int origin;
@@ -42,6 +49,7 @@ static tealet_t *new_main_checked(void) {
 
   main = tealet_initialize(&alloc, 0);
   assert(main != NULL);
+  tealet_test_lock_install(main, &g_lock_state);
   result = tealet_configure_check_stack(main, 0);
   assert(result == 0);
   return main;
@@ -91,11 +99,12 @@ static void test_basic_fork(void *far_marker) {
 
     /* Clean up */
     tealet_delete(other);
-    tealet_finalize(main);
+    finalize_main_checked(main);
 
     PASS();
   } else if (result == 0) {
     /* We are the child, other = parent */
+    tealet_test_lock_assert_unheld(&g_lock_state);
     assert_origin_main_fork(tealet_current(main));
     assert_origin_main(other);
     assert(testvalue == 0); /* Child should start with saved value */
@@ -150,6 +159,7 @@ static void test_fork_switch(void *far_marker) {
 
   if (result == 0) {
     /* We are the child */
+    tealet_test_lock_assert_unheld(&g_lock_state);
     assert_origin_main_fork(tealet_current(main));
     assert_origin_main(other);
     assert(testvalue == 0);    /* Child should start with saved value */
@@ -183,7 +193,7 @@ static void test_fork_switch(void *far_marker) {
     printf("  Parent: back from child, cleaning up\n");
   } /* Clean up - only parent gets here */
   tealet_delete(other);
-  tealet_finalize(main);
+  finalize_main_checked(main);
 
   PASS();
 }
@@ -247,7 +257,7 @@ static void test_multiple_forks(void *far_marker) {
   /* Clean up */
   tealet_delete(child1);
   tealet_delete(child2);
-  tealet_finalize(main);
+  finalize_main_checked(main);
 
   PASS();
 }
@@ -313,7 +323,7 @@ static void test_fork_switch_arg(void *far_marker) {
 
   /* Clean up - only parent gets here */
   tealet_delete(other);
-  tealet_finalize(main);
+  finalize_main_checked(main);
 
   PASS();
 }
@@ -358,7 +368,7 @@ static void test_fork_default_arg(void *far_marker) {
 
     /* Clean up */
     tealet_delete(child);
-    tealet_finalize(main);
+    finalize_main_checked(main);
 
     PASS();
   } else if (result == 0) {
@@ -434,7 +444,7 @@ static void test_ping_pong(void *far_marker) {
 
     /* Clean up */
     tealet_delete(child_saved);
-    tealet_finalize(main);
+    finalize_main_checked(main);
 
     PASS();
   } else {
@@ -497,7 +507,7 @@ static void test_new_previous(void *far_marker) {
   assert(tealet_current(main) == main);
   printf("  Main: returned from tealet_new(), tealet_previous() test passed\n");
 
-  tealet_finalize(main);
+  finalize_main_checked(main);
 
   PASS();
 }

--- a/tests/test_lock_helpers.h
+++ b/tests/test_lock_helpers.h
@@ -1,0 +1,72 @@
+#ifndef TEST_LOCK_HELPERS_H
+#define TEST_LOCK_HELPERS_H
+
+#include <assert.h>
+
+#include "tealet.h"
+
+/* Shared lock instrumentation for single-thread tests.
+ *
+ * We install a strict non-recursive fake lock callback pair and then assert:
+ * - every lock has a matching unlock,
+ * - lock depth returns to zero at test boundaries,
+ * - tealet run bodies execute with no lock held.
+ */
+typedef struct tealet_test_lock_state_t {
+  int depth;
+  int lock_calls;
+  int unlock_calls;
+} tealet_test_lock_state_t;
+
+static void tealet_test_lock_cb(void *arg) {
+  tealet_test_lock_state_t *state = (tealet_test_lock_state_t *)arg;
+  assert(state != NULL);
+  assert(state->depth == 0);
+  state->depth = 1;
+  state->lock_calls++;
+}
+
+static void tealet_test_unlock_cb(void *arg) {
+  tealet_test_lock_state_t *state = (tealet_test_lock_state_t *)arg;
+  assert(state != NULL);
+  assert(state->depth == 1);
+  state->depth = 0;
+  state->unlock_calls++;
+}
+
+static void tealet_test_lock_init(tealet_test_lock_state_t *state) {
+  assert(state != NULL);
+  state->depth = 0;
+  state->lock_calls = 0;
+  state->unlock_calls = 0;
+}
+
+static void tealet_test_lock_install(tealet_t *main_tealet, tealet_test_lock_state_t *state) {
+  tealet_lock_t locking;
+  int result;
+
+  assert(main_tealet != NULL);
+  tealet_test_lock_init(state);
+
+  locking.lock = tealet_test_lock_cb;
+  locking.unlock = tealet_test_unlock_cb;
+  locking.arg = (void *)state;
+
+  result = tealet_config_set_locking(main_tealet, &locking);
+  assert(result == 0);
+}
+
+/* Test-level end-of-scope safety check: no lock leak and balanced calls. */
+static void tealet_test_lock_assert_balanced(const tealet_test_lock_state_t *state) {
+  assert(state != NULL);
+  assert(state->depth == 0);
+  assert(state->lock_calls == state->unlock_calls);
+}
+
+/* Run-path guard: tealet code itself should execute outside the lock. */
+static void tealet_test_lock_assert_unheld(const tealet_test_lock_state_t *state) {
+  assert(state != NULL);
+  assert(state->depth == 0);
+}
+
+#endif

--- a/tests/test_stochastic.c
+++ b/tests/test_stochastic.c
@@ -7,6 +7,7 @@
  * - Dynamic creation and cleanup
  */
 #include "tealet.h"
+#include "test_lock_helpers.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -34,6 +35,7 @@ static int g_max_recursion_depth = DEFAULT_MAX_RECURSION_DEPTH;
 
 /* Main tealet */
 static tealet_t *g_main = NULL;
+static tealet_test_lock_state_t g_lock_state;
 
 /* Forward declaration */
 static tealet_t *worker_entry(tealet_t *current, void *arg);
@@ -101,6 +103,8 @@ static int worker_recursive(tealet_t *current, int depth) {
   int choice;
   tealet_t *target;
   int i;
+
+  tealet_test_lock_assert_unheld(&g_lock_state);
 
   /* Fill buffer to prevent optimization and consume stack */
   for (i = 0; i < 256; i++)
@@ -225,6 +229,8 @@ static tealet_t *worker_entry(tealet_t *current, void *arg) {
   int result;
   (void)arg;
 
+  tealet_test_lock_assert_unheld(&g_lock_state);
+
   /* Add ourselves to the registry */
   add_tealet(current);
 
@@ -311,9 +317,11 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "Failed to initialize\n");
     return 1;
   }
+  tealet_test_lock_install(g_main, &g_lock_state);
   configure_result = tealet_configure_check_stack(g_main, 0);
   if (configure_result != 0) {
     fprintf(stderr, "Failed to enable stack checks: %d\n", configure_result);
+    tealet_test_lock_assert_balanced(&g_lock_state);
     tealet_finalize(g_main);
     return 1;
   }
@@ -372,6 +380,7 @@ int main(int argc, char *argv[]) {
 
   print_stats("Final");
 
+  tealet_test_lock_assert_balanced(&g_lock_state);
   tealet_finalize(g_main);
 
   printf("\n✓ Test completed\n");

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -8,6 +8,7 @@
 
 #include "tealet.h"
 #include "tealet_extras.h"
+#include "test_lock_helpers.h"
 
 #if TEALET_WITH_TESTING
 /* Internal test hook from tealet.c (not part of public API). */
@@ -21,6 +22,7 @@ static int status = 0;
 static tealet_t *g_main = NULL;
 static tealet_t *the_stub = NULL;
 static int newmode = 0;
+static tealet_test_lock_state_t g_lock_state;
 
 /* Runtime detection of stats support */
 static int g_stats_enabled = 0;
@@ -82,17 +84,21 @@ static void check_stats(int verbose) {
     /* Each stack has one initial chunk (embedded in tealet_stack_t structure)
      */
     /* Additional chunks beyond the first add overhead for the chunk header */
-    /* Chunk header contains: next pointer, stack_near pointer, size field (~24
-     * bytes) */
+    /* Chunk header contains: next pointer, stack_near pointer, size field,
+     * and refcount. Header size is architecture/alignment dependent, so we
+     * compute an aligned overhead estimate below. */
     /*
      * Example: Stack with 2 chunks saving 288 bytes total
      *   - naive = 64 (struct overhead) + 288 (extent) = 352 bytes
-     *   - expanded = 64 + 144 (chunk1) + 24 (chunk2 header) + 144 (chunk2 data)
-     * = 376 bytes
-     *   - difference = 24 bytes (one extra chunk header)
+     *   - expanded = base + data + one extra chunk header + extra chunk data
+     *   - difference = one extra chunk header
      */
     size_t extra_chunks = stats.stack_chunk_count - stats.stack_count;
-    size_t max_overhead = extra_chunks * 24; /* approximate chunk header size */
+    size_t chunk_header_raw = sizeof(void *) * 2 + sizeof(size_t) + sizeof(int);
+    size_t chunk_header_align = sizeof(void *);
+    size_t chunk_header_overhead =
+        ((chunk_header_raw + chunk_header_align - 1) / chunk_header_align) * chunk_header_align;
+    size_t max_overhead = extra_chunks * chunk_header_overhead;
     if (stats.stack_bytes_expanded > stats.stack_bytes_naive + max_overhead) {
       fprintf(stderr,
               "INVARIANT FAIL: expanded=%zu > naive=%zu + overhead=%zu "
@@ -142,6 +148,26 @@ static void print_final_stats(void) {
 
 static tealet_alloc_t talloc = TEALET_ALLOC_INIT_MALLOC;
 static int talloc_fail = 0;
+
+typedef struct lock_snapshot_t {
+  int lock_calls;
+  int unlock_calls;
+} lock_snapshot_t;
+
+/* Capture cumulative callback counters so we can assert transition deltas
+ * around a single API operation.
+ */
+static void lock_snapshot_take(lock_snapshot_t *snap) {
+  snap->lock_calls = g_lock_state.lock_calls;
+  snap->unlock_calls = g_lock_state.unlock_calls;
+}
+
+/* Assert one lock/unlock pair occurred since the snapshot. */
+static void lock_snapshot_assert_delta_one(const lock_snapshot_t *before) {
+  assert(g_lock_state.lock_calls - before->lock_calls == 1);
+  assert(g_lock_state.unlock_calls - before->unlock_calls == 1);
+}
+
 void *failmalloc(size_t size, void *context) {
   if (talloc_fail)
     return 0;
@@ -156,6 +182,7 @@ void init_test_extra(tealet_alloc_t *alloc, size_t extrasize) {
   if (alloc == NULL)
     alloc = &talloc;
   g_main = tealet_initialize(alloc, extrasize);
+  tealet_test_lock_install(g_main, &g_lock_state);
   result = tealet_configure_check_stack(g_main, 0);
   assert(result == 0);
   assert(tealet_current(g_main) == g_main);
@@ -184,6 +211,7 @@ void fini_test() {
   if (g_stats_enabled) {
     assert(stats.n_active == 1); /* main tealet  only */
   }
+  tealet_test_lock_assert_balanced(&g_lock_state);
   tealet_finalize(g_main);
   g_main = NULL;
 }
@@ -445,6 +473,138 @@ void test_simple(void) {
   assert(t != NULL);
   assert(status == 1);
   fini_test();
+}
+
+typedef enum lock_transition_phase_e {
+  LOCK_PHASE_NONE = 0,
+  LOCK_PHASE_NEW_START = 1,
+  LOCK_PHASE_WAIT_RESUME = 2,
+  LOCK_PHASE_SWITCH_RESUME = 3,
+  LOCK_PHASE_STUB_RUN_START = 4,
+  LOCK_PHASE_DONE = 5,
+} lock_transition_phase_t;
+
+static lock_transition_phase_t g_lock_phase = LOCK_PHASE_NONE;
+static lock_snapshot_t g_lock_new_before;
+static lock_snapshot_t g_lock_switch_before;
+static lock_snapshot_t g_lock_exit_before;
+static lock_snapshot_t g_lock_stub_new_before;
+static lock_snapshot_t g_lock_stub_run_before;
+static lock_snapshot_t g_lock_fork_before;
+
+/* Transition accounting test for tealet_new + switch + exit.
+ * Verifies expected lock/unlock deltas at each phase boundary.
+ */
+static tealet_t *test_lock_transition_run(tealet_t *current, void *arg) {
+  (void)arg;
+
+  tealet_test_lock_assert_unheld(&g_lock_state);
+  assert(g_lock_phase == LOCK_PHASE_NEW_START);
+  lock_snapshot_assert_delta_one(&g_lock_new_before);
+
+  g_lock_phase = LOCK_PHASE_WAIT_RESUME;
+  tealet_switch(g_main, NULL);
+
+  tealet_test_lock_assert_unheld(&g_lock_state);
+  assert(g_lock_phase == LOCK_PHASE_SWITCH_RESUME);
+  lock_snapshot_assert_delta_one(&g_lock_switch_before);
+
+  lock_snapshot_take(&g_lock_exit_before);
+  g_lock_phase = LOCK_PHASE_DONE;
+  tealet_exit(g_main, NULL, TEALET_EXIT_DELETE);
+  assert(0);
+  return NULL;
+}
+
+/* Validate lock transition counts in the direct creation/switch path. */
+void test_lock_transitions(void) {
+  tealet_t *t;
+  int result;
+
+  init_test();
+
+  g_lock_phase = LOCK_PHASE_NEW_START;
+  lock_snapshot_take(&g_lock_new_before);
+  t = tealet_new_native(g_main, test_lock_transition_run, NULL, NULL);
+  assert(t != NULL);
+  assert(g_lock_phase == LOCK_PHASE_WAIT_RESUME);
+
+  lock_snapshot_take(&g_lock_switch_before);
+  g_lock_phase = LOCK_PHASE_SWITCH_RESUME;
+  result = tealet_switch(t, NULL);
+  assert(result == 0);
+  assert(g_lock_phase == LOCK_PHASE_DONE);
+
+  lock_snapshot_assert_delta_one(&g_lock_exit_before);
+
+  fini_test();
+}
+
+/* Transition accounting helper for tealet_stub_run() path. */
+static tealet_t *test_lock_transition_stub_run(tealet_t *current, void *arg) {
+  (void)arg;
+
+  tealet_test_lock_assert_unheld(&g_lock_state);
+  assert(g_lock_phase == LOCK_PHASE_STUB_RUN_START);
+  lock_snapshot_assert_delta_one(&g_lock_stub_run_before);
+
+  lock_snapshot_take(&g_lock_exit_before);
+  g_lock_phase = LOCK_PHASE_DONE;
+  tealet_exit(g_main, NULL, TEALET_EXIT_DELETE);
+  assert(0);
+  return NULL;
+}
+
+/* Validate lock transition counts for stub create and first run. */
+void test_lock_transitions_stub(void) {
+  tealet_t *stub;
+  int result;
+
+  init_test();
+
+  lock_snapshot_take(&g_lock_stub_new_before);
+  stub = tealet_stub_new(g_main, NULL);
+  assert(stub != NULL);
+  lock_snapshot_assert_delta_one(&g_lock_stub_new_before);
+
+  lock_snapshot_take(&g_lock_stub_run_before);
+  g_lock_phase = LOCK_PHASE_STUB_RUN_START;
+  result = tealet_stub_run(stub, test_lock_transition_stub_run, NULL);
+  assert(result == 0);
+  assert(g_lock_phase == LOCK_PHASE_DONE);
+
+  lock_snapshot_assert_delta_one(&g_lock_exit_before);
+
+  fini_test();
+}
+
+/* Validate lock transition count for tealet_fork(). */
+void test_lock_transitions_fork(void) {
+  tealet_t *other = NULL;
+  int result;
+  char far_marker = 0;
+
+  init_test();
+
+  result = tealet_set_far(g_main, &far_marker);
+  assert(result == 0);
+
+  lock_snapshot_take(&g_lock_fork_before);
+  result = tealet_fork(g_main, &other, NULL, TEALET_FORK_DEFAULT);
+  lock_snapshot_assert_delta_one(&g_lock_fork_before);
+
+  if (result == 1) {
+    assert(other != NULL);
+    tealet_delete(other);
+    fini_test();
+    return;
+  }
+
+  /* If we execute as child, this path should not continue after exit. */
+  assert(result == 0);
+  tealet_test_lock_assert_unheld(&g_lock_state);
+  tealet_exit(other, NULL, 0);
+  assert(0);
 }
 
 void test_simple_create(void) {
@@ -1068,6 +1228,9 @@ static test_entry_t test_list[] = {
     {"test_stack_further", test_stack_further},
     {"test_stack_far_isolation", test_stack_far_isolation},
     {"test_simple", test_simple},
+    {"test_lock_transitions", test_lock_transitions},
+    {"test_lock_transitions_stub", test_lock_transitions_stub},
+    {"test_lock_transitions_fork", test_lock_transitions_fork},
     {"test_simple_create", test_simple_create},
     {"test_simple_create_and_run", test_simple_create_and_run},
     {"test_create_previous", test_create_previous},


### PR DESCRIPTION
## Summary
- Refine locking policy so libtealet auto-locks only the five switching APIs:
  - tealet_new()
  - tealet_create()
  - tealet_switch()
  - tealet_exit()
  - tealet_fork()
- Keep non-switch APIs integrator-managed for cross-thread locking (for example tealet_delete()/tealet_duplicate()).
- Add/adjust lock transition tests, including fork-path transition coverage.
- Add debug-only best-effort sanity verification (tealet_verify_current_matches_caller) that checks caller stack ordering against current->stack_far for bounded stacks.
- Update API/architecture documentation to explain the asymmetry rationale and locking expectations.

## Why
Switching operations are temporally asymmetric: execution can leave at one call boundary and continue at a different logical point. Keeping lock ownership inside the switching APIs removes brittle cross-frame lock management from integrator code.

## Notes
- The debug caller/current check is intentionally best-effort and catches some (not all) foreign-thread misuse.
- Stub helpers in tealet_extras.h are switching wrappers by inference and inherit switching lock behavior.

## Validation
- make format
- make test
