### PR TITLE
Switch/exit flags + status-return create APIs + docs/changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Switch/exit behavior is now explicit via flags**
+  - `tealet_switch()` now takes a `flags` parameter and supports:
+    - `TEALET_SWITCH_DEFAULT`
+    - `TEALET_SWITCH_FORCE`
+    - `TEALET_SWITCH_PANIC`
+  - `TEALET_SWITCH_FORCE` / `TEALET_EXIT_FORCE` semantics are now documented explicitly, including the main-stack edge case where `TEALET_ERR_MEM` can still occur under FORCE.
+
+- **Creation APIs now return status codes with out-parameters**
+  - `tealet_new()` and `tealet_create()` now return `int` status and report created tealets via out-pointers.
+  - `tealet_stub_new()` in extras/helpers follows the same status-return pattern.
+  - Call sites and examples were migrated to the status-first style.
+
+- **Implicit run-return exit policy hardened and documented**
+  - Automatic exit on run-function return now uses an explicit retry/fallback policy:
+    - requested target (default)
+    - panic+force to main on defunct target
+    - requested target with FORCE on memory failure
+    - panic+force to main if FORCE still cannot complete transfer
+  - API docs now include a concise robust manual `tealet_exit()` pattern for implementors.
+
+### Documentation
+- Updated `README.md`, `docs/API.md`, `docs/ARCHITECTURE.md`, and `docs/GETTING_STARTED.md` to reflect the new signatures and behavioral semantics.
+
 ## [0.5.1] - 2026-05-08
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ CLANG_FORMAT ?= clang-format
 DOXYGEN ?= doxygen
 DOXYFILE ?= Doxyfile
 DOC_OUTPUT_DIR ?= docs/_build/doxygen
+SCRIPT_DIR ?= scripts
 
 coreobj = src/tealet.o #src/switch_S.o src/switch_c.o
 allobj = $(coreobj) src/tealet_extras.o
@@ -105,45 +106,12 @@ endif
 # Use `make check-version-sync` in CI/release checks to prevent drift.
 
 check-version-sync:
-	@set -e; \
-	header_version=$$(awk -F'"' '/^#define TEALET_VERSION "[0-9]+\.[0-9]+\.[0-9]+"/ {print $$2; exit}' src/tealet.h); \
-	if [ -z "$$header_version" ]; then \
-		echo "ERROR: Could not parse TEALET_VERSION from src/tealet.h"; \
-		exit 1; \
-	fi; \
-	make_version=$$(awk -F'[[:space:]]*=[[:space:]]*' '/^VERSION[[:space:]]*=/ {print $$2; exit}' Makefile); \
-	readme_version=$$(sed -n 's/^\*\*Version \([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)\*\*$$/\1/p' README.md | head -n 1); \
-	doxy_version=$$(awk -F'[[:space:]]*=[[:space:]]*' '/^PROJECT_NUMBER[[:space:]]*=/ {print $$2; exit}' Doxyfile); \
-	if [ "$$make_version" != "$$header_version" ]; then \
-		echo "ERROR: Makefile VERSION ($$make_version) != src/tealet.h TEALET_VERSION ($$header_version)"; \
-		exit 1; \
-	fi; \
-	if [ "$$readme_version" != "$$header_version" ]; then \
-		echo "ERROR: README.md version ($$readme_version) != src/tealet.h TEALET_VERSION ($$header_version)"; \
-		exit 1; \
-	fi; \
-	if [ "$$doxy_version" != "$$header_version" ]; then \
-		echo "ERROR: Doxyfile PROJECT_NUMBER ($$doxy_version) != src/tealet.h TEALET_VERSION ($$header_version)"; \
-		exit 1; \
-	fi; \
-	echo "*** Version sync OK: $$header_version ***"
+	@$(SCRIPT_DIR)/sync-version.sh -check
 
 sync-version:
-	@set -e; \
-	version=$$(awk -F'"' '/^#define TEALET_VERSION "[0-9]+\.[0-9]+\.[0-9]+"/ {print $$2; exit}' src/tealet.h); \
-	if [ -z "$$version" ]; then \
-		echo "ERROR: Could not parse TEALET_VERSION from src/tealet.h"; \
-		exit 1; \
-	fi; \
-	awk -v v="$$version" 'BEGIN{done=0} { if (!done && $$0 ~ /^VERSION[[:space:]]*=/) { print "VERSION = " v; done=1; next } print }' Makefile > Makefile.new; \
-	mv Makefile.new Makefile; \
-	awk -v v="$$version" 'BEGIN{done=0} { if (!done && $$0 ~ /^\*\*Version [0-9]+\.[0-9]+\.[0-9]+\*\*$$/) { print "**Version " v "**"; done=1; next } print }' README.md > README.md.new; \
-	mv README.md.new README.md; \
-	awk -v v="$$version" 'BEGIN{done=0} { if (!done && $$0 ~ /^PROJECT_NUMBER[[:space:]]*=/) { print "PROJECT_NUMBER         = " v; done=1; next } print }' Doxyfile > Doxyfile.new; \
-	mv Doxyfile.new Doxyfile; \
-	$(MAKE) check-version-sync
+	@$(SCRIPT_DIR)/sync-version.sh
 
-# Proposed changelog rolling helpers
+# Changelog rolling helpers
 # Usage:
 #   make roll-changelog ROLL_VERSION=0.5.2 ROLL_DATE=2026-05-08
 # Defaults:
@@ -162,72 +130,10 @@ ROLL_VERSION ?= $(VERSION)
 ROLL_DATE ?= $(shell date +%F)
 
 check-changelog-roll:
-	@set -e; \
-	if ! grep -q '^## \[Unreleased\]$$' CHANGELOG.md; then \
-		echo "ERROR: CHANGELOG.md missing '## [Unreleased]' section"; \
-		exit 1; \
-	fi; \
-	if ! grep -q '^\[Unreleased\]: .*compare/v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.\.\.HEAD$$' CHANGELOG.md; then \
-		echo "ERROR: CHANGELOG.md missing canonical [Unreleased] compare footer link"; \
-		exit 1; \
-	fi; \
-	echo "*** Changelog roll prerequisites OK ***"
+	@$(SCRIPT_DIR)/roll-changelog.sh -check
 
 roll-changelog: check-changelog-roll
-	@set -e; \
-	v="$(ROLL_VERSION)"; \
-	d="$(ROLL_DATE)"; \
-	if ! echo "$$v" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
-		echo "ERROR: ROLL_VERSION must be x.y.z, got '$$v'"; \
-		exit 1; \
-	fi; \
-	if ! echo "$$d" | grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}$$'; then \
-		echo "ERROR: ROLL_DATE must be YYYY-MM-DD, got '$$d'"; \
-		exit 1; \
-	fi; \
-	if grep -q "^## \[$$v\]" CHANGELOG.md; then \
-		echo "ERROR: CHANGELOG.md already has section for $$v"; \
-		exit 1; \
-	fi; \
-	if grep -q "^\[$$v\]: " CHANGELOG.md; then \
-		echo "ERROR: CHANGELOG.md already has footer link for $$v"; \
-		exit 1; \
-	fi; \
-	prev=$$(sed -n 's@^\[Unreleased\]: .*compare/v\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)\.\.\.HEAD$$@\1@p' CHANGELOG.md | head -n 1); \
-	if [ -z "$$prev" ]; then \
-		echo "ERROR: Could not parse previous release version from [Unreleased] footer link"; \
-		exit 1; \
-	fi; \
-	awk -v v="$$v" -v d="$$d" -v p="$$prev" '\
-	BEGIN { inserted = 0; links = 0 } \
-	{ \
-	  if (!inserted && $$0 == "## [Unreleased]") { \
-	    print $$0; \
-	    print ""; \
-	    print "## [" v "] - " d; \
-	    inserted = 1; \
-	    next; \
-	  } \
-	  if ($$0 ~ /^\[Unreleased\]: /) { \
-	    print "[Unreleased]: https://github.com/kristjanvalur/libtealet/compare/v" v "...HEAD"; \
-	    print "[" v "]: https://github.com/kristjanvalur/libtealet/compare/v" p "...v" v; \
-	    links = 1; \
-	    next; \
-	  } \
-	  print $$0; \
-	} \
-	END { \
-	  if (!inserted) { \
-	    print "ERROR: Unreleased section insertion point not found" > "/dev/stderr"; \
-	    exit 1; \
-	  } \
-	  if (!links) { \
-	    print "ERROR: Unreleased footer link insertion point not found" > "/dev/stderr"; \
-	    exit 1; \
-	  } \
-	}' CHANGELOG.md > CHANGELOG.md.new; \
-	mv CHANGELOG.md.new CHANGELOG.md; \
-	echo "*** Rolled CHANGELOG.md to $$v ($$d), previous base $$prev ***"
+	@$(SCRIPT_DIR)/roll-changelog.sh "$(ROLL_VERSION)" "$(ROLL_DATE)"
 
 # Release metadata rollup helper:
 # - validates/syncs version metadata from src/tealet.h

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ int main(void) {
     tealet_t *main = tealet_initialize(&alloc, 0);
     
     void *arg = NULL;
-    tealet_t *coro = tealet_new(main, worker, &arg, NULL);
+    tealet_t *coro = NULL;
+    if (tealet_new(main, &coro, worker, &arg, NULL) != 0) {
+        tealet_finalize(main);
+        return 1;
+    }
     
     tealet_finalize(main);
     return 0;

--- a/docs/API.md
+++ b/docs/API.md
@@ -400,7 +400,7 @@ Suspend current tealet and resume target tealet.
 - `0` on success
 - `TEALET_ERR_MEM` on memory allocation failure while saving/restoring state
 - `TEALET_ERR_DEFUNCT` if target is defunct
-- `TEALET_ERR_PANIC` on main when control was rerouted to main from `tealet_exit()` because the requested exit target was defunct
+- `TEALET_ERR_PANIC` when resumed due to an explicit panic-tagged `tealet_exit()` transfer
 - Negative error code on failure
 
 **Usage:**
@@ -463,6 +463,8 @@ Exit current tealet and transfer control to target.
 - `TEALET_EXIT_DELETE`: Auto-delete tealet on exit (same as return behavior)
 - `TEALET_EXIT_DEFER`:  Store flags and argument, return to caller.  Will be used when
   tealet exits later.
+- `TEALET_EXIT_FORCE`: Force the requested transfer despite save-time memory pressure by defuncting affected non-main stacks as needed
+- `TEALET_EXIT_PANIC`: Tag the receiving tealet's resumed switch return as `TEALET_ERR_PANIC`
 
 **Usage:**
 ```c
@@ -494,20 +496,21 @@ tealet_t *my_run(tealet_t *current, void *arg) {
 }
 ```
 
-This function does not return unless `TEALET_EXIT_DEFER` is set.
+This function does not return on successful transfer.
 
 **Returns:**
 - `0` only when `TEALET_EXIT_DEFER` is used (deferred exit setup succeeds)
 - Negative error code on failure
-    - May include `TEALET_ERR_MEM` and `TEALET_ERR_DEFUNCT`
+    - `TEALET_ERR_MEM` when save/restore cannot complete and `TEALET_EXIT_FORCE` is not set
+    - `TEALET_ERR_DEFUNCT` when the requested target is defunct
+    - `TEALET_ERR_INVAL` for invalid flag combinations (for example `TEALET_EXIT_DEFER | TEALET_EXIT_PANIC`)
 
-When exit to a non-main target fails, the implementation falls back to exiting to `main`.
+`tealet_exit()` does not implicitly reroute to another target.
 
-If the chosen exit target is defunct, this fallback path reroutes the exit to `main`.
+With `TEALET_EXIT_FORCE`, low-memory save failures are handled in non-failable mode
+by marking affected non-main stacks/tealets defunct so the requested transfer can proceed.
 
 **Note:** Returning from the run function automatically deletes the tealet. Use `tealet_exit()` when you need explicit control over deletion or want to exit from nested calls within the run function.
-
-Future direction: a dedicated panic API may be added (for example, `tealet_panic()`), either forcing switch-to-main with a panic flag or returning a dedicated panic error code for corrupt stack-state scenarios.
 
 ---
 
@@ -1160,7 +1163,7 @@ Error handling in libtealet is intentionally narrow:
 - **Runtime/resource errors out of user control:**
     - `TEALET_ERR_MEM`
     - `TEALET_ERR_DEFUNCT`
-    - `TEALET_ERR_PANIC` (main-only switch outcome)
+    - `TEALET_ERR_PANIC` (explicit panic-tagged resume)
 - **Other negative returns** are generally caused by incorrect API usage (invalid context, invalid switching flow, integrity/caller sanity violations) and should be treated as effectively fatal programming errors.
 
 ### Practical handling guide
@@ -1168,7 +1171,7 @@ Error handling in libtealet is intentionally narrow:
 For `tealet_switch()`:
 - On `TEALET_ERR_MEM`: treat as transient resource failure; free optional resources and either retry later or abort the coroutine workflow cleanly.
 - On `TEALET_ERR_DEFUNCT`: treat target as unusable, inspect status, and delete/replace that tealet.
-- On `TEALET_ERR_PANIC` (main only): treat as emergency reroute signal from `tealet_exit()`; report and terminate cleanly.
+- On `TEALET_ERR_PANIC`: treat as explicit panic resume signal from `tealet_exit(..., TEALET_EXIT_PANIC)`.
 
 For `tealet_new()`:
 - The same underlying switch failure conditions apply (`TEALET_ERR_MEM`, `TEALET_ERR_DEFUNCT`, `TEALET_ERR_PANIC`), but the API surface is pointer-based, so these failures are observed as `NULL`.
@@ -1178,14 +1181,14 @@ Practical note for `tealet_switch()` failures (`TEALET_ERR_MEM`, `TEALET_ERR_DEF
 - In the main tealet, the usual recovery path is to report the error and terminate the thread/process cleanly.
 
 For `tealet_exit()`:
-- In normal (non-`TEALET_EXIT_DEFER`) use, `tealet_exit()` is the panic path: it first attempts the requested target and then attempts fallback to `main`.
-- To preserve forward progress during low-memory exit paths, the implementation may accept degraded state and mark affected saved stacks/tealets as defunct.
-- If the requested target is defunct, exit is rerouted to `main`.
+- Without `TEALET_EXIT_FORCE`, failures (including `TEALET_ERR_MEM` and `TEALET_ERR_DEFUNCT`) are returned directly.
+- With `TEALET_EXIT_FORCE`, low-memory save failures may defunct affected non-main saved stacks/tealets so the requested transfer can proceed.
+- The requested target is never implicitly replaced by `main`; panic reroute must be explicit.
 - The main tealet itself is never marked defunct.
 
 ### Note
 
-`TEALET_ERR_PANIC` is currently the dedicated signal for reroute-to-main panic conditions after `tealet_exit()` target failure.
+`TEALET_ERR_PANIC` is the explicit panic-resume signal produced by `tealet_exit(..., TEALET_EXIT_PANIC)`.
 
 ---
 
@@ -1252,10 +1255,10 @@ if (result == TEALET_ERR_DEFUNCT) {
 #define TEALET_ERR_PANIC (-6)
 ```
 
-Main-tealet switch result signaling panic reroute.
+Switch result signaling explicit panic-tagged resume.
 
 **When returned:**
-- Returned by `tealet_switch()` in `main` when a non-main tealet called `tealet_exit()` to a defunct target and libtealet rerouted the exit to `main`.
+- Returned by `tealet_switch()` when the resumed tealet was targeted via `tealet_exit(..., TEALET_EXIT_PANIC)`.
 
 **Recovery:**
 - Treat as fatal control-flow anomaly for the coroutine workflow.

--- a/docs/API.md
+++ b/docs/API.md
@@ -62,31 +62,37 @@ There is no supported way to decouple this deletion order: tealet API operations
 ### tealet_create()
 
 ```c
-tealet_t *tealet_create(tealet_t *main, tealet_run_t run, void *stack_far);
+int tealet_create(tealet_t *main, tealet_t **pcreated, tealet_run_t run, void *stack_far);
 ```
 
 Create a new tealet without starting it.
 
 **Parameters:**
 - `main`: The main tealet (from `tealet_initialize()`)
+- `pcreated`: Output pointer for the created tealet (must be non-NULL)
 - `run`: Function to execute in the tealet's context
 - `stack_far`: Optional far-boundary requirement for the initial stack snapshot (`NULL` uses default). This acts as a minimum boundary: it can only extend capture range, never shrink it.
 
-**Returns:** New tealet in `TEALET_STATUS_INITIAL` state, or `NULL` on allocation failure.
+**Returns:**
+- `0` on success
+- negative `TEALET_ERR_*` on failure (`TEALET_ERR_MEM`, `TEALET_ERR_INVAL`, etc.)
 
 **Usage:**
 ```c
-tealet_t *t = tealet_create(main, my_run_function, NULL);
-if (t == NULL) {
-    /* Out of memory */
+tealet_t *t = NULL;
+int rc = tealet_create(main, &t, my_run_function, NULL);
+if (rc != 0) {
+    /* Handle failure */
 }
 ```
 
 The tealet is created but not yet running. Use `tealet_switch()` to start execution. This pattern is useful when setting up multiple coroutines before starting any:
 
 ```c
-tealet_t *t1 = tealet_create(main, func1, NULL);
-tealet_t *t2 = tealet_create(main, func2, NULL);
+tealet_t *t1 = NULL;
+tealet_t *t2 = NULL;
+tealet_create(main, &t1, func1, NULL);
+tealet_create(main, &t2, func2, NULL);
 /* Both created but not running yet */
 
 void *arg1 = data1;
@@ -100,35 +106,48 @@ tealet_switch(t1, &arg1);  /* Start t1 */
 ### tealet_new()
 
 ```c
-tealet_t *tealet_new(tealet_t *main, tealet_run_t run, void **parg, void *stack_far);
+int tealet_new(tealet_t *main, tealet_t **pcreated, tealet_run_t run, void **parg, void *stack_far);
 ```
 
 Create a new tealet and immediately start executing it.
 
 **Parameters:**
 - `main`: The main tealet
+- `pcreated`: Optional output pointer for the created tealet (may be `NULL`)
 - `run`: Function to execute
 - `parg`: Pointer to argument pointer (passed to run function, updated with return value)
 - `stack_far`: Optional far-boundary requirement for the initial stack snapshot (`NULL` uses default). This acts as a minimum boundary: it can only extend capture range, never shrink it.
 
-**Returns:** New tealet (may be `NULL` if run function deleted it), or `NULL` on failure.
+**Returns:**
+- `0` on success
+- `TEALET_ERR_MEM` on failure to create/start due to memory pressure
+- `TEALET_ERR_PANIC` when startup resumes via unexpected panic-tagged switch-back
+
+`tealet_new()` now reports status via its integer return value; it does not use
+`NULL` as an error carrier.
 
 Conceptually, `tealet_new()` is `tealet_create()` followed by `tealet_switch()` (create-and-start in one call).
 
-`tealet_new()` performs an internal switch as part of create-and-start. The same switch failure conditions as `tealet_switch()` apply (`TEALET_ERR_MEM`, `TEALET_ERR_DEFUNCT`, `TEALET_ERR_PANIC`), but `tealet_new()` reports them as `NULL` rather than returning an error code.
+`tealet_new()` performs an internal switch as part of create-and-start.
+In practice, it fails with `TEALET_ERR_MEM`, or it can return
+`TEALET_ERR_PANIC` to signal an unexpected panic-tagged switch-back.
 
 **Usage:**
 ```c
 void *arg = my_data;
-tealet_t *t = tealet_new(main, my_run, &arg, NULL);
+tealet_t *t = NULL;
+int rc = tealet_new(main, &t, my_run, &arg, NULL);
+if (rc != 0) {
+    /* Handle failure */
+}
 /* Run function has executed until first switch back */
 /* arg now contains value from first switch */
 ```
 
 Equivalent to:
 ```c
-tealet_t *t = tealet_create(main, run, NULL);
-if (t != NULL) {
+tealet_t *t = NULL;
+if (tealet_create(main, &t, run, NULL) == 0) {
     tealet_switch(t, parg);
 }
 ```
@@ -162,7 +181,7 @@ void bar(tealet_t *main) {
     arg = &local_state;
     stack_far = tealet_stack_further(&local_state, &local_state + 1);
 
-    worker = tealet_new(main, my_run, &arg, stack_far);
+    tealet_new(main, &worker, my_run, &arg, stack_far);
     (void)worker;
 }
 ```
@@ -735,21 +754,22 @@ Use this to combine boundary requirements from different stack references.
 ### tealet_new_probe()
 
 ```c
-void *tealet_new_probe(tealet_t *dummy1, tealet_run_t dummy2, void **dummy3, void *dummy4);
+void *tealet_new_probe(tealet_t *dummy1, tealet_t **dummy2, tealet_run_t dummy3,
+                       void **dummy4, void *dummy5);
 ```
 
 A function to test what stack boundary would be used for a new tealet without creating one. This is mostly informative.
 
 **Parameters:**
-- `dummy1`, `dummy2`, `dummy3`: Unused placeholders to match the `tealet_new()` call shape
-- `dummy4`: Optional far-boundary requirement; if provided, it is clamped so it can only extend (not shrink) the probe boundary
+- `dummy1`, `dummy2`, `dummy3`, `dummy4`: Unused placeholders to match the `tealet_new()` call shape
+- `dummy5`: Optional far-boundary requirement; if provided, it is clamped so it can only extend (not shrink) the probe boundary
 
 **Returns:** The probed stack-boundary marker.
 
 **Usage:**
 ```c
 void *arg = NULL;
-void *probe = tealet_new_probe(main, my_run, &arg, NULL);
+void *probe = tealet_new_probe(main, NULL, my_run, &arg, NULL);
 printf("new tealet boundary probe: %p\n", probe);
 ```
 
@@ -1174,7 +1194,8 @@ For `tealet_switch()`:
 - On `TEALET_ERR_PANIC`: treat as explicit panic resume signal from `tealet_exit(..., TEALET_EXIT_PANIC)`.
 
 For `tealet_new()`:
-- The same underlying switch failure conditions apply (`TEALET_ERR_MEM`, `TEALET_ERR_DEFUNCT`, `TEALET_ERR_PANIC`), but the API surface is pointer-based, so these failures are observed as `NULL`.
+- `TEALET_ERR_MEM` is the creation/start failure case.
+- `TEALET_ERR_PANIC` is not a memory failure; it signals an unexpected panic-tagged switch-back during create-and-start.
 
 Practical note for `tealet_switch()` failures (`TEALET_ERR_MEM`, `TEALET_ERR_DEFUNCT`, `TEALET_ERR_PANIC`):
 - In non-main tealets, the usual recovery path is to perform local cleanup and then exit to `main`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -424,8 +424,17 @@ Suspend current tealet and resume target tealet.
 - Negative error code on failure
 
 `TEALET_SWITCH_FORCE` applies the same non-failable save behavior as
-`TEALET_EXIT_FORCE`: on low-memory save pressure, affected non-main saved
-stacks may be marked defunct so the requested transfer can proceed.
+`TEALET_EXIT_FORCE`:
+- without FORCE, save-time memory failures are returned (`TEALET_ERR_MEM`)
+- with FORCE, save-time memory failures are ignored so the requested transfer can proceed
+    by marking affected non-main saved stacks/tealets defunct.
+
+`TEALET_SWITCH_FORCE` can still return `TEALET_ERR_MEM` when the only way to
+continue would require main-stack growth that fails under memory pressure.
+Main is never marked defunct, so this edge case remains a hard memory failure.
+
+This means a successful forced switch can make other tealets become defunct as
+the trade-off for forward progress under memory pressure.
 
 **Usage:**
 ```c
@@ -531,10 +540,54 @@ This function does not return on successful transfer.
 
 `tealet_exit()` does not implicitly reroute to another target.
 
-With `TEALET_EXIT_FORCE`, low-memory save failures are handled in non-failable mode
-by marking affected non-main stacks/tealets defunct so the requested transfer can proceed.
+`TEALET_EXIT_FORCE` mirrors `TEALET_SWITCH_FORCE` behavior:
+- without FORCE, save-time memory failures are returned (`TEALET_ERR_MEM`)
+- with FORCE, save-time memory failures are ignored so the requested transfer can proceed
+    by marking affected non-main saved stacks/tealets defunct.
 
-**Note:** Returning from the run function automatically deletes the tealet. Use `tealet_exit()` when you need explicit control over deletion or want to exit from nested calls within the run function.
+`TEALET_EXIT_FORCE` can still return `TEALET_ERR_MEM` when the only way to
+continue would require main-stack growth that fails under memory pressure.
+Main is never marked defunct, so this edge case remains a hard memory failure.
+
+This means a successful forced exit can make other tealets become defunct as
+the trade-off for forward progress under memory pressure.
+
+**Note:** Returning from the run function automatically deletes the tealet using
+an implicit `tealet_exit()` policy: try requested target, panic+force to main
+if target is defunct, retry requested target with FORCE on memory failure, and
+if FORCE still fails (including the main-stack edge above), panic+force to main.
+Use `tealet_exit()` when you need explicit control over deletion or want to
+exit from nested calls within the run function.
+
+**Manual robust `tealet_exit()` pattern (equivalent intent):**
+```c
+/* Non-returning helper. abort() documents unreachable return. */
+static void robust_exit(tealet_t *self, tealet_t *target, void *arg, int base_flags) {
+    int r;
+
+    /* 1) Fast path: requested target, caller policy flags. */
+    r = tealet_exit(target, arg, base_flags);
+
+    /* 2) Defunct target: panic+force fallback to main. */
+    if (r == TEALET_ERR_DEFUNCT) {
+        (void)tealet_exit(self->main, arg, base_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE);
+        abort();
+    }
+
+    /* 3) Memory pressure: retry requested target with FORCE. */
+    if (r == TEALET_ERR_MEM) {
+        r = tealet_exit(target, arg, base_flags | TEALET_EXIT_FORCE);
+
+        /* 4) FORCE may still fail in main-stack growth edge case. */
+        if (r == TEALET_ERR_MEM || r == TEALET_ERR_DEFUNCT) {
+            (void)tealet_exit(self->main, arg, base_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE);
+            abort();
+        }
+    }
+
+    abort();
+}
+```
 
 ---
 
@@ -970,7 +1023,10 @@ Explicitly delete a tealet and free its resources.
 
 **Usage:**
 ```c
-tealet_t *t = tealet_create(main, my_run, NULL);
+tealet_t *t = NULL;
+if (tealet_create(main, &t, my_run, NULL) != 0) {
+    /* Handle create failure */
+}
 /* Use t... */
 tealet_delete(t);
 ```
@@ -1199,23 +1255,27 @@ For `tealet_switch()`:
 - On `TEALET_ERR_PANIC`: treat as explicit panic resume signal from
     `tealet_exit(..., TEALET_EXIT_PANIC)` or `tealet_switch(..., TEALET_SWITCH_PANIC)`.
 
+Forced transfer note (`tealet_switch(..., TEALET_SWITCH_FORCE)` and
+`tealet_exit(..., TEALET_EXIT_FORCE)`):
+- these APIs can succeed while ignoring save-time memory errors
+- in that success path, affected non-main saved stacks/tealets may be marked defunct.
+
 For `tealet_new()`:
 - `TEALET_ERR_MEM` is the creation/start failure case.
 - `TEALET_ERR_PANIC` is not a memory failure; it signals an unexpected panic-tagged switch-back during create-and-start.
 
-Practical note for `tealet_switch()` failures (`TEALET_ERR_MEM`, `TEALET_ERR_DEFUNCT`, `TEALET_ERR_PANIC`):
+Practical note for switch/exit failures:
 - In non-main tealets, the usual recovery path is to perform local cleanup and then exit to `main`.
 - In the main tealet, the usual recovery path is to report the error and terminate the thread/process cleanly.
 
-For `tealet_exit()`:
-- Without `TEALET_EXIT_FORCE`, failures (including `TEALET_ERR_MEM` and `TEALET_ERR_DEFUNCT`) are returned directly.
-- With `TEALET_EXIT_FORCE`, low-memory save failures may defunct affected non-main saved stacks/tealets so the requested transfer can proceed.
+For `tealet_exit()` specifically:
 - The requested target is never implicitly replaced by `main`; panic reroute must be explicit.
 - The main tealet itself is never marked defunct.
 
 ### Note
 
-`TEALET_ERR_PANIC` is the explicit panic-resume signal produced by `tealet_exit(..., TEALET_EXIT_PANIC)`.
+`TEALET_ERR_PANIC` is the explicit panic-resume signal produced by
+`tealet_exit(..., TEALET_EXIT_PANIC)` or `tealet_switch(..., TEALET_SWITCH_PANIC)`.
 
 ---
 
@@ -1236,8 +1296,8 @@ Memory allocation failed.
 
 **Example:**
 ```c
-tealet_t *t = tealet_create(main, my_run, NULL);
-if (t == NULL) {
+tealet_t *t = NULL;
+if (tealet_create(main, &t, my_run, NULL) != 0) {
     fprintf(stderr, "Out of memory\n");
     return TEALET_ERR_MEM;
 }
@@ -1254,6 +1314,9 @@ if (t == NULL) {
 Target tealet is defunct (invalid for switching).
 
 **Causes:**
+- Successful forced transfer under memory pressure (`TEALET_SWITCH_FORCE` or
+    `TEALET_EXIT_FORCE`) can ignore save-time memory errors and mark affected
+    non-main saved stacks/tealets defunct.
 - Saved stack became invalid (for example due to a non-recoverable save/grow failure path)
 - Tealet was left in an unusable state by an internal failure path
 - Caller attempted to switch to a non-switchable tealet handle
@@ -1341,15 +1404,18 @@ Used with `tealet_exit()`.
 **Example Comparison:**
 ```c
 /* Pattern 1: Create then switch (more control) */
-tealet_t *t1 = tealet_create(main, func1, NULL);
-tealet_t *t2 = tealet_create(main, func2, NULL);
+tealet_t *t1 = NULL;
+tealet_t *t2 = NULL;
+tealet_create(main, &t1, func1, NULL);
+tealet_create(main, &t2, func2, NULL);
 setup_relationship(t1, t2);  /* Both exist but not started */
 void *arg = t2;
 tealet_switch(t1, &arg, TEALET_SWITCH_DEFAULT);  /* Now start t1 */
 
 /* Pattern 2: Create and start (more concise) */
 void *arg = my_data;
-tealet_t *t = tealet_new(main, my_func, &arg, NULL);
+tealet_t *t = NULL;
+tealet_new(main, &t, my_func, &arg, NULL);
 /* Already started, arg contains first return value */
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1151,16 +1151,19 @@ Initialize a wrapper allocator that tracks active allocation count and total byt
 ### tealet_stub_new()
 
 ```c
-tealet_t *tealet_stub_new(tealet_t *tealet, void *stack_far);
+int tealet_stub_new(tealet_t *tealet, tealet_t **pstub, void *stack_far);
 ```
 
 Create a paused stub tealet that can later run arbitrary functions via `tealet_stub_run()`.
 
 **Parameters:**
 - `tealet`: Main/owner tealet context
+- `pstub`: Output pointer receiving the created stub tealet on success
 - `stack_far`: Optional far-boundary requirement for the initial stub stack snapshot (`NULL` uses default). This behaves like `tealet_create()`/`tealet_new()`: it can only extend capture range, never shrink it.
 
-**Returns:** New stub tealet, or `NULL` on allocation failure.
+**Returns:**
+- `0` on success
+- Negative `TEALET_ERR_*` on failure
 
 ### tealet_stub_run()
 
@@ -1500,9 +1503,9 @@ tealet_t *worker_run(tealet_t *current, void *arg) {
     return current->main;
 }
 
-tealet_t *stub = tealet_stub_new(main, NULL);
-if (stub == NULL) {
-    /* allocation failure */
+tealet_t *stub = NULL;
+if (tealet_stub_new(main, &stub, NULL) != 0) {
+    /* allocation/setup failure */
 }
 
 tealet_t *clone = tealet_duplicate(stub);

--- a/docs/API.md
+++ b/docs/API.md
@@ -96,7 +96,7 @@ tealet_create(main, &t2, func2, NULL);
 /* Both created but not running yet */
 
 void *arg1 = data1;
-tealet_switch(t1, &arg1);  /* Start t1 */
+tealet_switch(t1, &arg1, TEALET_SWITCH_DEFAULT);  /* Start t1 */
 ```
 
 **See Also:** `tealet_new()` for create-and-start in one call.
@@ -148,7 +148,7 @@ Equivalent to:
 ```c
 tealet_t *t = NULL;
 if (tealet_create(main, &t, run, NULL) == 0) {
-    tealet_switch(t, parg);
+    tealet_switch(t, parg, TEALET_SWITCH_DEFAULT);
 }
 ```
 
@@ -221,7 +221,7 @@ tealet_t *my_run(tealet_t *current, void *arg) {
     
     /* Do work, possibly switching to other tealets */
     void *data = process(arg);
-    tealet_switch(current->main, &data);
+    tealet_switch(current->main, &data, TEALET_SWITCH_DEFAULT);
     
     /* More work */
     
@@ -363,7 +363,7 @@ int main(void) {
         
         /* Switch to child with an argument */
         arg = (void*)0x5678;
-        tealet_switch(other, &arg);
+        tealet_switch(other, &arg, TEALET_SWITCH_DEFAULT);
         printf("Parent: child returned with arg=%p\n", arg);
         
         /* Clean up */
@@ -406,7 +406,7 @@ This feature mirrors functionality from Stackless Python but was historically om
 ### tealet_switch()
 
 ```c
-int tealet_switch(tealet_t *target, void **parg);
+int tealet_switch(tealet_t *target, void **parg, int flags);
 ```
 
 Suspend current tealet and resume target tealet.
@@ -414,18 +414,23 @@ Suspend current tealet and resume target tealet.
 **Parameters:**
 - `target`: Tealet to switch to
 - `parg`: Pointer to argument pointer (passed to target, updated with return value)
+- `flags`: Switch control flags (`TEALET_SWITCH_DEFAULT`, `TEALET_SWITCH_FORCE`, `TEALET_SWITCH_PANIC`)
 
 **Returns:** 
 - `0` on success
 - `TEALET_ERR_MEM` on memory allocation failure while saving/restoring state
 - `TEALET_ERR_DEFUNCT` if target is defunct
-- `TEALET_ERR_PANIC` when resumed due to an explicit panic-tagged `tealet_exit()` transfer
+- `TEALET_ERR_PANIC` when resumed due to an explicit panic-tagged transfer (`tealet_exit()` or `tealet_switch()` with panic)
 - Negative error code on failure
+
+`TEALET_SWITCH_FORCE` applies the same non-failable save behavior as
+`TEALET_EXIT_FORCE`: on low-memory save pressure, affected non-main saved
+stacks may be marked defunct so the requested transfer can proceed.
 
 **Usage:**
 ```c
 void *arg = my_data;
-int result = tealet_switch(target, &arg);
+int result = tealet_switch(target, &arg, TEALET_SWITCH_DEFAULT);
 if (result == 0) {
     /* arg now contains value passed back from target */
 } else {
@@ -445,7 +450,7 @@ tealet_t *ping(tealet_t *current, void *arg) {
     tealet_t *pong = (tealet_t*)arg;
     
     void *data = "ping";
-    tealet_switch(pong, &data);
+    tealet_switch(pong, &data, TEALET_SWITCH_DEFAULT);
     /* data now contains "pong" */
     
     return current->main;
@@ -453,7 +458,7 @@ tealet_t *ping(tealet_t *current, void *arg) {
 
 tealet_t *pong(tealet_t *current, void *arg) {
     void *data = "pong";
-    tealet_switch(arg, &data);  /* Switch back to ping */
+    tealet_switch(arg, &data, TEALET_SWITCH_DEFAULT);  /* Switch back to ping */
     return current->main;
 }
 ```
@@ -607,7 +612,7 @@ switch (status) {
 ```c
 while (tealet_status(gen) == TEALET_STATUS_ACTIVE) {
     process(value);
-    tealet_switch(gen, &value);  /* Get next value */
+    tealet_switch(gen, &value, TEALET_SWITCH_DEFAULT);  /* Get next value */
 }
 ```
 
@@ -1191,7 +1196,8 @@ Error handling in libtealet is intentionally narrow:
 For `tealet_switch()`:
 - On `TEALET_ERR_MEM`: treat as transient resource failure; free optional resources and either retry later or abort the coroutine workflow cleanly.
 - On `TEALET_ERR_DEFUNCT`: treat target as unusable, inspect status, and delete/replace that tealet.
-- On `TEALET_ERR_PANIC`: treat as explicit panic resume signal from `tealet_exit(..., TEALET_EXIT_PANIC)`.
+- On `TEALET_ERR_PANIC`: treat as explicit panic resume signal from
+    `tealet_exit(..., TEALET_EXIT_PANIC)` or `tealet_switch(..., TEALET_SWITCH_PANIC)`.
 
 For `tealet_new()`:
 - `TEALET_ERR_MEM` is the creation/start failure case.
@@ -1260,7 +1266,7 @@ Target tealet is defunct (invalid for switching).
 
 **Example:**
 ```c
-int result = tealet_switch(t, &arg);
+int result = tealet_switch(t, &arg, TEALET_SWITCH_DEFAULT);
 if (result == TEALET_ERR_DEFUNCT) {
     fprintf(stderr, "Tealet has exited\n");
     tealet_delete(t);
@@ -1279,7 +1285,8 @@ if (result == TEALET_ERR_DEFUNCT) {
 Switch result signaling explicit panic-tagged resume.
 
 **When returned:**
-- Returned by `tealet_switch()` when the resumed tealet was targeted via `tealet_exit(..., TEALET_EXIT_PANIC)`.
+- Returned by `tealet_switch()` when the resumed tealet was targeted via
+    `tealet_exit(..., TEALET_EXIT_PANIC)` or `tealet_switch(..., TEALET_SWITCH_PANIC)`.
 
 **Recovery:**
 - Treat as fatal control-flow anomaly for the coroutine workflow.
@@ -1306,6 +1313,11 @@ Switch result signaling explicit panic-tagged resume.
 #define TEALET_EXIT_DEFAULT 0  /* Don't auto-delete */
 #define TEALET_EXIT_DELETE  1  /* Auto-delete on exit */
 #define TEALET_EXIT_DEFER   2  /* Defer exit to return */
+
+/* Switch flags */
+#define TEALET_SWITCH_DEFAULT 0  /* Default switch behavior */
+#define TEALET_SWITCH_FORCE   4  /* Force switch despite save-time memory failures */
+#define TEALET_SWITCH_PANIC   8  /* Mark receiving tealet as panic-resumed */
 ```
 
 Used with `tealet_exit()`.
@@ -1333,7 +1345,7 @@ tealet_t *t1 = tealet_create(main, func1, NULL);
 tealet_t *t2 = tealet_create(main, func2, NULL);
 setup_relationship(t1, t2);  /* Both exist but not started */
 void *arg = t2;
-tealet_switch(t1, &arg);  /* Now start t1 */
+tealet_switch(t1, &arg, TEALET_SWITCH_DEFAULT);  /* Now start t1 */
 
 /* Pattern 2: Create and start (more concise) */
 void *arg = my_data;
@@ -1466,7 +1478,7 @@ tealet_t *counter_run(tealet_t *current, void *arg) {
     while (state->current < state->max) {
         void *value = (void*)(intptr_t)state->current;
         state->current++;
-        tealet_switch(current->main, &value);
+        tealet_switch(current->main, &value, TEALET_SWITCH_DEFAULT);
     }
     
     return current->main;
@@ -1482,8 +1494,8 @@ int main(void) {
     }
     
     /* Create counter tealet */
-    tealet_t *counter = tealet_create(main, counter_run, NULL);
-    if (counter == NULL) {
+    tealet_t *counter = NULL;
+    if (tealet_create(main, &counter, counter_run, NULL) != 0) {
         fprintf(stderr, "Failed to create counter\n");
         tealet_finalize(main);
         return 1;
@@ -1492,7 +1504,7 @@ int main(void) {
     /* Start it */
     int max = 5;
     void *arg = &max;
-    int result = tealet_switch(counter, &arg);
+    int result = tealet_switch(counter, &arg, TEALET_SWITCH_DEFAULT);
     if (result != 0) {
         fprintf(stderr, "Switch failed: %d\n", result);
         tealet_delete(counter);
@@ -1505,7 +1517,7 @@ int main(void) {
         int value = (int)(intptr_t)arg;
         printf("Value: %d\n", value);
         
-        result = tealet_switch(counter, &arg);
+        result = tealet_switch(counter, &arg, TEALET_SWITCH_DEFAULT);
         if (result != 0) {
             fprintf(stderr, "Switch failed: %d\n", result);
             break;

--- a/docs/API.md
+++ b/docs/API.md
@@ -132,6 +132,11 @@ Conceptually, `tealet_new()` is `tealet_create()` followed by `tealet_switch()` 
 In practice, it fails with `TEALET_ERR_MEM`, or it can return
 `TEALET_ERR_PANIC` to signal an unexpected panic-tagged switch-back.
 
+Even when `tealet_new()` returns `0`, the value stored in `pcreated` may
+already be invalid: the created tealet may have run and been deleted before
+returning (for example by returning from `run`, via
+`tealet_exit(..., TEALET_EXIT_DELETE)`, or any other deletion path).
+
 **Usage:**
 ```c
 void *arg = my_data;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -447,7 +447,7 @@ In the current implementation, this sharing is introduced by duplication paths (
 ### High-Level Flow
 
 ```c
-int tealet_switch(tealet_t *target, void **parg) {
+int tealet_switch(tealet_t *target, void **parg, int flags) {
     g_main->g_target = target;
     g_main->g_arg = *parg;
     

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -90,7 +90,11 @@ int main(void) {
     
     /* Create and run a coroutine */
     void *arg = "Hello World";
-    tealet_t *coro = tealet_new(main, hello_run, &arg, NULL);
+    tealet_t *coro = NULL;
+    if (tealet_new(main, &coro, hello_run, &arg, NULL) != 0) {
+        tealet_finalize(main);
+        return 1;
+    }
     
     /* Clean up */
     tealet_finalize(main);
@@ -122,7 +126,7 @@ tealet_t *my_run(tealet_t *current, void *arg) {
     void *ptr = &local_value;
     
     /* DANGER: Switching invalidates local_value */
-    tealet_switch(current->main, &ptr);
+    tealet_switch(current->main, &ptr, TEALET_SWITCH_DEFAULT);
     /* ptr now points to invalid stack data */
     
     return current->main;
@@ -138,7 +142,7 @@ tealet_t *my_run(tealet_t *current, void *arg) {
     *heap_value = 42;
     void *ptr = heap_value;
     
-    tealet_switch(current->main, &ptr);
+    tealet_switch(current->main, &ptr, TEALET_SWITCH_DEFAULT);
     /* ptr still valid */
     
     free(heap_value);
@@ -189,7 +193,8 @@ int main(void) {
     tealet_t *main = tealet_initialize(&alloc, 0);
     
     void *arg = NULL;
-    tealet_t *worker = tealet_new(main, worker_run, &arg, NULL);
+    tealet_t *worker = NULL;
+    tealet_new(main, &worker, worker_run, &arg, NULL);
     /* worker may already be deleted here! */
     
     int status = tealet_status(worker);  /* ❌ Dangling pointer! */
@@ -216,7 +221,8 @@ int main(void) {
     tealet_t *main = tealet_initialize(&alloc, 0);
     
     void *arg = NULL;
-    tealet_t *worker = tealet_new(main, worker_run, &arg, NULL);
+    tealet_t *worker = NULL;
+    tealet_new(main, &worker, worker_run, &arg, NULL);
     /* worker still exists and can be queried */
     
     int status = tealet_status(worker);  /* ✅ Safe */
@@ -263,7 +269,7 @@ tealet_t *fire_and_forget(tealet_t *current, void *arg) {
 tealet_t *controlled_worker(tealet_t *current, void *arg) {
     while (should_continue()) {
         do_work();
-        tealet_switch(current->main, NULL);  /* Yield back */
+        tealet_switch(current->main, NULL, TEALET_SWITCH_DEFAULT);  /* Yield back */
     }
     tealet_exit(current->main, NULL, TEALET_EXIT_DEFAULT);  /* Don't auto-delete */
     return current->main;
@@ -271,11 +277,12 @@ tealet_t *controlled_worker(tealet_t *current, void *arg) {
 
 int main(void) {
     /* ... */
-    tealet_t *worker = tealet_new(main, controlled_worker, &arg, NULL);
+    tealet_t *worker = NULL;
+    tealet_new(main, &worker, controlled_worker, &arg, NULL);
     
     /* Can switch back to worker multiple times */
-    tealet_switch(worker, NULL);
-    tealet_switch(worker, NULL);
+    tealet_switch(worker, NULL, TEALET_SWITCH_DEFAULT);
+    tealet_switch(worker, NULL, TEALET_SWITCH_DEFAULT);
     
     /* Manual cleanup when done */
     tealet_delete(worker);
@@ -296,7 +303,7 @@ tealet_t *ping_run(tealet_t *current, void *arg) {
     
     for (int i = 0; i < 3; i++) {
         printf("Ping %d\n", i);
-        tealet_switch(pong, NULL);
+        tealet_switch(pong, NULL, TEALET_SWITCH_DEFAULT);
     }
     
     return current->main;
@@ -307,7 +314,7 @@ tealet_t *pong_run(tealet_t *current, void *arg) {
     
     for (int i = 0; i < 3; i++) {
         printf("  Pong %d\n", i);
-        tealet_switch(ping, NULL);
+        tealet_switch(ping, NULL, TEALET_SWITCH_DEFAULT);
     }
     
     return current->main;
@@ -318,16 +325,18 @@ int main(void) {
     tealet_t *main = tealet_initialize(&alloc, 0);
     
     /* Create both coroutines */
-    tealet_t *ping = tealet_create(main, ping_run, NULL);
-    tealet_t *pong = tealet_create(main, pong_run, NULL);
+    tealet_t *ping = NULL;
+    tealet_t *pong = NULL;
+    tealet_create(main, &ping, ping_run, NULL);
+    tealet_create(main, &pong, pong_run, NULL);
     
     /* Start ping, passing pong as argument */
     void *arg = pong;
-    tealet_switch(ping, &arg);
+    tealet_switch(ping, &arg, TEALET_SWITCH_DEFAULT);
     
     /* Start pong, passing ping as argument */
     arg = ping;
-    tealet_switch(pong, &arg);
+    tealet_switch(pong, &arg, TEALET_SWITCH_DEFAULT);
     
     tealet_delete(ping);
     tealet_delete(pong);
@@ -358,7 +367,7 @@ tealet_t *range_run(tealet_t *current, void *arg) {
     for (int i = 0; i < max; i++) {
         /* Yield value back to caller */
         void *value = (void*)(intptr_t)i;
-        tealet_switch(current->main, &value);
+        tealet_switch(current->main, &value, TEALET_SWITCH_DEFAULT);
     }
     
     return current->main;
@@ -371,12 +380,13 @@ int main(void) {
     /* Create generator for range(5) */
     int max = 5;
     void *arg = &max;
-    tealet_t *gen = tealet_new(main, range_run, &arg, NULL);
+    tealet_t *gen = NULL;
+    tealet_new(main, &gen, range_run, &arg, NULL);
     
     /* Pull values from generator */
     while (tealet_status(gen) == TEALET_STATUS_ACTIVE) {
         printf("%d\n", (int)(intptr_t)arg);
-        tealet_switch(gen, &arg);
+        tealet_switch(gen, &arg, TEALET_SWITCH_DEFAULT);
     }
     
     tealet_delete(gen);
@@ -415,7 +425,7 @@ tealet_t *producer_run(tealet_t *current, void *arg) {
         printf("Produced: %d\n", *ctx->buffer);
         
         /* Switch to consumer */
-        tealet_switch(ctx->consumer, NULL);
+        tealet_switch(ctx->consumer, NULL, TEALET_SWITCH_DEFAULT);
     }
     
     return current->main;
@@ -431,7 +441,7 @@ tealet_t *consumer_run(tealet_t *current, void *arg) {
         ctx->count++;
         
         /* Switch back to producer */
-        tealet_switch(producer, NULL);
+        tealet_switch(producer, NULL, TEALET_SWITCH_DEFAULT);
     }
     
     return current->main;
@@ -445,12 +455,14 @@ int main(void) {
     int *buffer = malloc(sizeof(int));
     
     /* Create consumer first */
-    tealet_t *consumer = tealet_create(main, consumer_run, NULL);
+    tealet_t *consumer = NULL;
+    tealet_create(main, &consumer, consumer_run, NULL);
     
     /* Create producer context */
     producer_ctx_t ctx = {consumer, buffer, 0};
     void *arg = &ctx;
-    tealet_t *producer = tealet_new(main, producer_run, &arg, NULL);
+    tealet_t *producer = NULL;
+    tealet_new(main, &producer, producer_run, &arg, NULL);
     
     printf("Total consumed: %d items\n", ctx.count);
     
@@ -467,7 +479,8 @@ int main(void) {
 
 ```c
 void *arg = my_data;
-tealet_t *t = tealet_new(main, my_run, &arg, NULL);
+tealet_t *t = NULL;
+tealet_new(main, &t, my_run, &arg, NULL);
 /* Returns when my_run switches back */
 /* arg now contains return value */
 ```
@@ -477,27 +490,28 @@ Use when you want to start execution immediately.
 ### `tealet_create()` + `tealet_switch()` - Deferred Start
 
 ```c
-tealet_t *t = tealet_create(main, my_run, NULL);
+tealet_t *t = NULL;
+tealet_create(main, &t, my_run, NULL);
 /* Tealet created but not yet running */
 
 void *arg = my_data;
-tealet_switch(t, &arg);  /* Now it starts */
+tealet_switch(t, &arg, TEALET_SWITCH_DEFAULT);  /* Now it starts */
 ```
 
 Use when you need to set up multiple coroutines before starting any.
 
 ## Error Handling
 
-Functions return `NULL` or negative error codes on failure:
+Functions return negative error codes on failure (and write created tealets via out-parameters):
 
 ```c
-tealet_t *t = tealet_create(main, my_run, NULL);
-if (t == NULL) {
+tealet_t *t = NULL;
+if (tealet_create(main, &t, my_run, NULL) != 0) {
     fprintf(stderr, "Failed to create tealet (out of memory)\n");
     return TEALET_ERR_MEM;
 }
 
-int result = tealet_switch(t, &arg);
+int result = tealet_switch(t, &arg, TEALET_SWITCH_DEFAULT);
 if (result == TEALET_ERR_DEFUNCT) {
     fprintf(stderr, "Target tealet is corrupt\n");
     return -1;
@@ -527,11 +541,13 @@ if (tealet_status(t) == TEALET_STATUS_DEFUNCT) {
 ```c
 /* Thread 1 */
 tealet_t *main1 = tealet_initialize(&alloc, 0);
-tealet_t *t1 = tealet_create(main1, func1, NULL);
+tealet_t *t1 = NULL;
+tealet_create(main1, &t1, func1, NULL);
 
 /* Thread 2 */
 tealet_t *main2 = tealet_initialize(&alloc, 0);
-tealet_t *t2 = tealet_create(main2, func2, NULL);
+tealet_t *t2 = NULL;
+tealet_create(main2, &t2, func2, NULL);
 
 /* ❌ WRONG: Can't switch between t1 and t2 (different mains) */
 /* ✅ OK: Can switch within same thread between t1 and other tealets from main1 */

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -194,7 +194,6 @@ int main(void) {
     
     void *arg = NULL;
     tealet_t *worker = NULL;
-    /* Assume tealet_new() returns 0 in this illustration. */
     tealet_new(main, &worker, worker_run, &arg, NULL);
     /* worker may already be deleted here! */
     
@@ -223,7 +222,6 @@ int main(void) {
     
     void *arg = NULL;
     tealet_t *worker = NULL;
-    /* Assume tealet_new() returns 0 in this illustration. */
     tealet_new(main, &worker, worker_run, &arg, NULL);
     /* worker still exists and can be queried */
     

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -194,6 +194,7 @@ int main(void) {
     
     void *arg = NULL;
     tealet_t *worker = NULL;
+    /* Assume tealet_new() returns 0 in this illustration. */
     tealet_new(main, &worker, worker_run, &arg, NULL);
     /* worker may already be deleted here! */
     
@@ -222,6 +223,7 @@ int main(void) {
     
     void *arg = NULL;
     tealet_t *worker = NULL;
+    /* Assume tealet_new() returns 0 in this illustration. */
     tealet_new(main, &worker, worker_run, &arg, NULL);
     /* worker still exists and can be queried */
     

--- a/scripts/roll-changelog.sh
+++ b/scripts/roll-changelog.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+if [[ "${1:-}" == "-check" || "${1:-}" == "--check" ]]; then
+  if ! grep -q '^## \[Unreleased\]$' CHANGELOG.md; then
+    echo "ERROR: CHANGELOG.md missing '## [Unreleased]' section"
+    exit 1
+  fi
+
+  if ! grep -q '^\[Unreleased\]: .*compare/v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.\.\.HEAD$' CHANGELOG.md; then
+    echo "ERROR: CHANGELOG.md missing canonical [Unreleased] compare footer link"
+    exit 1
+  fi
+
+  echo "*** Changelog roll prerequisites OK ***"
+  exit 0
+fi
+
+roll_version="${1:-}"
+roll_date="${2:-}"
+
+if [[ -z "$roll_version" ]]; then
+  roll_version=$(awk -F'[[:space:]]*=[[:space:]]*' '/^VERSION[[:space:]]*=/ {print $2; exit}' Makefile)
+fi
+if [[ -z "$roll_date" ]]; then
+  roll_date=$(date +%F)
+fi
+
+if ! [[ "$roll_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "ERROR: ROLL_VERSION must be x.y.z, got '$roll_version'"
+  exit 1
+fi
+if ! [[ "$roll_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  echo "ERROR: ROLL_DATE must be YYYY-MM-DD, got '$roll_date'"
+  exit 1
+fi
+
+if grep -q "^## \[$roll_version\]" CHANGELOG.md; then
+  echo "ERROR: CHANGELOG.md already has section for $roll_version"
+  exit 1
+fi
+if grep -q "^\[$roll_version\]: " CHANGELOG.md; then
+  echo "ERROR: CHANGELOG.md already has footer link for $roll_version"
+  exit 1
+fi
+
+prev=$(sed -n 's@^\[Unreleased\]: .*compare/v\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)\.\.\.HEAD$@\1@p' CHANGELOG.md | head -n 1)
+if [[ -z "$prev" ]]; then
+  echo "ERROR: Could not parse previous release version from [Unreleased] footer link"
+  exit 1
+fi
+
+awk -v v="$roll_version" -v d="$roll_date" -v p="$prev" '
+BEGIN { inserted = 0; links = 0 }
+{
+  if (!inserted && $0 == "## [Unreleased]") {
+    print $0;
+    print "";
+    print "## [" v "] - " d;
+    inserted = 1;
+    next;
+  }
+  if ($0 ~ /^\[Unreleased\]: /) {
+    print "[Unreleased]: https://github.com/kristjanvalur/libtealet/compare/v" v "...HEAD";
+    print "[" v "]: https://github.com/kristjanvalur/libtealet/compare/v" p "...v" v;
+    links = 1;
+    next;
+  }
+  print $0;
+}
+END {
+  if (!inserted) {
+    print "ERROR: Unreleased section insertion point not found" > "/dev/stderr";
+    exit 1;
+  }
+  if (!links) {
+    print "ERROR: Unreleased footer link insertion point not found" > "/dev/stderr";
+    exit 1;
+  }
+}' CHANGELOG.md > CHANGELOG.md.new
+mv CHANGELOG.md.new CHANGELOG.md
+
+echo "*** Rolled CHANGELOG.md to $roll_version ($roll_date), previous base $prev ***"

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+if [[ "${1:-}" == "-check" || "${1:-}" == "--check" ]]; then
+  header_version=$(awk -F'"' '/^#define TEALET_VERSION "[0-9]+\.[0-9]+\.[0-9]+"/ {print $2; exit}' src/tealet.h)
+  if [[ -z "$header_version" ]]; then
+    echo "ERROR: Could not parse TEALET_VERSION from src/tealet.h"
+    exit 1
+  fi
+
+  make_version=$(awk -F'[[:space:]]*=[[:space:]]*' '/^VERSION[[:space:]]*=/ {print $2; exit}' Makefile)
+  readme_version=$(sed -n 's/^\*\*Version \([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)\*\*$/\1/p' README.md | head -n 1)
+  doxy_version=$(awk -F'[[:space:]]*=[[:space:]]*' '/^PROJECT_NUMBER[[:space:]]*=/ {print $2; exit}' Doxyfile)
+
+  if [[ "$make_version" != "$header_version" ]]; then
+    echo "ERROR: Makefile VERSION ($make_version) != src/tealet.h TEALET_VERSION ($header_version)"
+    exit 1
+  fi
+  if [[ "$readme_version" != "$header_version" ]]; then
+    echo "ERROR: README.md version ($readme_version) != src/tealet.h TEALET_VERSION ($header_version)"
+    exit 1
+  fi
+  if [[ "$doxy_version" != "$header_version" ]]; then
+    echo "ERROR: Doxyfile PROJECT_NUMBER ($doxy_version) != src/tealet.h TEALET_VERSION ($header_version)"
+    exit 1
+  fi
+
+  echo "*** Version sync OK: $header_version ***"
+  exit 0
+fi
+
+version=$(awk -F'"' '/^#define TEALET_VERSION "[0-9]+\.[0-9]+\.[0-9]+"/ {print $2; exit}' src/tealet.h)
+if [[ -z "$version" ]]; then
+  echo "ERROR: Could not parse TEALET_VERSION from src/tealet.h"
+  exit 1
+fi
+
+awk -v v="$version" 'BEGIN{done=0} { if (!done && $0 ~ /^VERSION[[:space:]]*=/) { print "VERSION = " v; done=1; next } print }' Makefile > Makefile.new
+mv Makefile.new Makefile
+
+awk -v v="$version" 'BEGIN{done=0} { if (!done && $0 ~ /^\*\*Version [0-9]+\.[0-9]+\.[0-9]+\*\*$/) { print "**Version " v "**"; done=1; next } print }' README.md > README.md.new
+mv README.md.new README.md
+
+awk -v v="$version" 'BEGIN{done=0} { if (!done && $0 ~ /^PROJECT_NUMBER[[:space:]]*=/) { print "PROJECT_NUMBER         = " v; done=1; next } print }' Doxyfile > Doxyfile.new
+mv Doxyfile.new Doxyfile
+
+"$repo_root/scripts/sync-version.sh" -check

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1442,16 +1442,22 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
      * 1) Try requested target in fail-fast mode.
      * 2) If target is defunct, panic to main explicitly.
      * 3) If memory blocked the transfer, retry requested target with FORCE.
+     * 4) If FORCE still cannot complete (for example main-stack growth would
+     *    be required and main cannot be marked defunct), panic+force to main.
      */
     result = tealet_exit((tealet_t *)g_exit_target, exit_arg, exit_flags);
     if (result == TEALET_ERR_DEFUNCT) {
       retry_flags = exit_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
-      (void)tealet_exit((tealet_t *)g_main, exit_arg, retry_flags);
+      result = tealet_exit((tealet_t *)g_main, exit_arg, retry_flags);
     } else if (result == TEALET_ERR_MEM) {
       retry_flags = exit_flags | TEALET_EXIT_FORCE;
-      (void)tealet_exit((tealet_t *)g_exit_target, exit_arg, retry_flags);
+      result = tealet_exit((tealet_t *)g_exit_target, exit_arg, retry_flags);
+      if (result == TEALET_ERR_DEFUNCT || result == TEALET_ERR_MEM) {
+        retry_flags = exit_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
+        result = tealet_exit((tealet_t *)g_main, exit_arg, retry_flags);
+      }
     }
-    assert(!"This point should not be reached");
+    assert(!"Implicit return transfer failed");
   } else {
     /* Either just a create, with no run, or a switch back
      * into the tealet_new()

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1070,11 +1070,12 @@ static int tealet_save_state(tealet_main_t *g_main, void *old_stack_pointer) {
 
   exiting = ((g_current->flags & TEALET_TFLAGS_EXITING) != 0);
   force = ((g_current->flags & TEALET_TFLAGS_EXITFORCE) != 0);
-  /* Force mode is used by tealet_exit() to request non-failable save
-   * behavior under memory pressure. A stack that cannot be saved may be
-   * marked defunct so the switch can proceed.
+  /* Force mode requests non-failable save behavior under memory pressure.
+   * A stack that cannot be saved may be marked defunct so the switch can
+   * proceed. The main tealet is never marked defunct; forced saves from main
+   * must still fail with MEM.
    */
-  fail_ok = !force;
+  fail_ok = (!force || TEALET_IS_MAIN((tealet_t *)g_current));
 
   /* save and unlink older stacks on demand */
   /* when coming from unbounded stack, there should be no list of unsaved stacks
@@ -1452,12 +1453,16 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
     } else if (result == TEALET_ERR_MEM) {
       retry_flags = exit_flags | TEALET_EXIT_FORCE;
       result = tealet_exit((tealet_t *)g_exit_target, exit_arg, retry_flags);
-      if (result == TEALET_ERR_DEFUNCT || result == TEALET_ERR_MEM) {
+      if (result < 0) {
         retry_flags = exit_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
         result = tealet_exit((tealet_t *)g_main, exit_arg, retry_flags);
       }
+    } else if (result < 0) {
+      retry_flags = exit_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
+      result = tealet_exit((tealet_t *)g_main, exit_arg, retry_flags);
     }
     assert(!"Implicit return transfer failed");
+    abort();
   } else {
     /* Either just a create, with no run, or a switch back
      * into the tealet_new()

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1712,21 +1712,41 @@ done:
  * the lock internally.
  */
 
-int tealet_switch(tealet_t *stub, void **parg) {
+int tealet_switch(tealet_t *stub, void **parg, int flags) {
   tealet_sub_t *g_target = (tealet_sub_t *)stub;
   tealet_sub_t *g_current;
+  int force_requested;
+  int panic_requested;
   int result;
   tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
+
+  if ((flags & ~(TEALET_SWITCH_FORCE | TEALET_SWITCH_PANIC)) != 0)
+    return TEALET_ERR_INVAL;
+
+  force_requested = ((flags & TEALET_SWITCH_FORCE) != 0);
+  panic_requested = ((flags & TEALET_SWITCH_PANIC) != 0);
 
   tealet_lock_switch(g_main);
   g_current = g_main->g_current;
   tealet_verify_current_matches_caller(g_current);
+
+  if (force_requested)
+    g_current->flags |= TEALET_TFLAGS_EXITFORCE;
+  if (panic_requested)
+    g_main->g_flags |= TEALET_MFLAGS_PANIC;
+
   if (g_target == g_current) {
     g_main->g_previous = g_current;
     result = 0; /* switch to self */
   } else {
     result = tealet_switchstack(g_main, g_target, parg ? *parg : NULL, parg);
   }
+
+  if (panic_requested && result < 0)
+    g_main->g_flags &= ~TEALET_MFLAGS_PANIC;
+  if (force_requested)
+    g_current->flags &= ~TEALET_TFLAGS_EXITFORCE;
+
   tealet_unlock_switch(g_main);
   return result;
 }

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1139,6 +1139,7 @@ static void tealet_restore_state(tealet_main_t *g_main, void *new_stack_pointer)
 
   /* Restore the heap copy back into the C stack */
   assert(g->stack != NULL);
+  assert(new_stack_pointer == g->stack->chunk.stack_near);
   tealet_stack_restore(g->stack);
   tealet_stack_decref(g_main, g->stack);
   g->stack = NULL;

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1743,7 +1743,7 @@ int tealet_switch(tealet_t *stub, void **parg, int flags) {
 
   if (g_target == g_current) {
     g_main->g_previous = g_current;
-    result = 0; /* switch to self */
+    result = panic_requested ? TEALET_ERR_PANIC : 0; /* switch to self */
   } else {
     result = tealet_switchstack(g_main, g_target, parg ? *parg : NULL, parg);
   }
@@ -1768,7 +1768,7 @@ static int tealet_exit_inner(tealet_t *target, void *arg, int flags) {
 
   assert(g_current != (tealet_sub_t *)g_main); /* mustn't exit main */
   if (g_target == g_current)
-    return -2; /* invalid tealet */
+    return TEALET_ERR_INVAL; /* invalid tealet */
 
   g_current->flags |= TEALET_TFLAGS_EXITING;
   if (flags & TEALET_EXIT_FORCE)

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1611,17 +1611,21 @@ static void *tealet_pick_initial_far(void *default_far, void *hint) {
  * `tealet_switch()`, `tealet_exit()`, `tealet_fork()`) acquire/release
  * the lock internally.
  */
-tealet_t *tealet_new(tealet_t *tealet, tealet_run_t run, void **parg, void *stack_far) {
+int tealet_new(tealet_t *tealet, tealet_t **pcreated, tealet_run_t run, void **parg, void *stack_far) {
   tealet_sub_t *result; /* store this until we return */
   int fail;
+  int api_result;
   void *arg = NULL;
   void *default_far;
   void *stack_far_used;
   tealet_main_t *g_main = TEALET_GET_MAIN(tealet);
+  if (pcreated != NULL)
+    *pcreated = NULL;
   tealet_lock_switch(g_main);
   assert(!g_main->g_target);
   result = tealet_alloc(g_main);
   if (result == NULL) {
+    api_result = TEALET_ERR_MEM;
     goto done; /* Could not allocate */
   }
   default_far = (void *)&result;
@@ -1630,11 +1634,15 @@ tealet_t *tealet_new(tealet_t *tealet, tealet_run_t run, void **parg, void *stac
   if (fail) {
     /* could not save stack */
     tealet_delete((tealet_t *)result);
-    result = NULL;
+    api_result = fail;
+    goto done;
   }
+  if (pcreated != NULL)
+    *pcreated = (tealet_t *)result;
+  api_result = 0;
 done:
   tealet_unlock_switch(g_main);
-  return (tealet_t *)result;
+  return api_result;
 }
 
 /* create a tealet by saving the target stack and switching
@@ -1646,14 +1654,19 @@ done:
  * `tealet_switch()`, `tealet_exit()`, `tealet_fork()`) acquire/release
  * the lock internally.
  */
-tealet_t *tealet_create(tealet_t *tealet, tealet_run_t run, void *stack_far) {
+int tealet_create(tealet_t *tealet, tealet_t **pcreated, tealet_run_t run, void *stack_far) {
   tealet_sub_t *result; /* store this until we return */
   int fail;
+  int api_result;
   void *default_far;
   void *stack_far_used;
   tealet_main_t *g_main = TEALET_GET_MAIN(tealet);
   tealet_sub_t *previous;
   tealet_sub_t *current;
+
+  if (pcreated == NULL)
+    return TEALET_ERR_INVAL;
+  *pcreated = NULL;
 
   tealet_lock_switch(g_main);
   previous = g_main->g_previous;
@@ -1661,8 +1674,10 @@ tealet_t *tealet_create(tealet_t *tealet, tealet_run_t run, void *stack_far) {
   tealet_verify_current_matches_caller(current);
   assert(!g_main->g_target);
   result = tealet_alloc(g_main);
-  if (result == NULL)
+  if (result == NULL) {
+    api_result = TEALET_ERR_MEM;
     goto done; /* Could not allocate */
+  }
   /* we turn into the new tealet and switch back, in order
    * to save the new tealet's stack at this position
    */
@@ -1674,17 +1689,19 @@ tealet_t *tealet_create(tealet_t *tealet, tealet_run_t run, void *stack_far) {
     /* could not save stack */
     tealet_delete((tealet_t *)result);
     g_main->g_current = current;
-    result = NULL;
+    api_result = fail;
   } else {
     /* restore g_previous to whatever it was.  We don't count
      * this switch from the temporary tealet back to us
      * as proper switch in that sense
      */
     g_main->g_previous = previous;
+    *pcreated = (tealet_t *)result;
+    api_result = 0;
   }
 done:
   tealet_unlock_switch(g_main);
-  return (tealet_t *)result;
+  return api_result;
 }
 
 /* Switch to a tealet and back.
@@ -2262,15 +2279,16 @@ void *tealet_stack_further(void *a, void *b) {
 #pragma warning(push)
 #pragma warning(disable : 4172)
 #endif
-void *tealet_new_probe(tealet_t *d1, tealet_run_t d2, void **d3, void *d4) {
+void *tealet_new_probe(tealet_t *d1, tealet_t **d2, tealet_run_t d3, void **d4, void *d5) {
   tealet_sub_t *result;
   void *default_far;
   void *r;
   (void)d1;
   (void)d2;
   (void)d3;
+  (void)d4;
   default_far = (void *)&result;
-  r = tealet_pick_initial_far(default_far, d4);
+  r = tealet_pick_initial_far(default_far, d5);
   return r;
 }
 #if __GNUC__ > 4

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1136,10 +1136,14 @@ static int tealet_save_state(tealet_main_t *g_main, void *old_stack_pointer) {
 
 static void tealet_restore_state(tealet_main_t *g_main, void *new_stack_pointer) {
   tealet_sub_t *g = g_main->g_target;
+  (void)new_stack_pointer;
 
   /* Restore the heap copy back into the C stack */
   assert(g->stack != NULL);
-  assert(new_stack_pointer == g->stack->chunk.stack_near);
+  /* TODO(stackman): re-enable a restore stack-pointer assertion once
+   * STACKMAN_OP_RESTORE callback stack_pointer semantics are consistent
+   * across all backends.
+   */
   tealet_stack_restore(g->stack);
   tealet_stack_decref(g_main, g->stack);
   g->stack = NULL;

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -50,6 +50,7 @@
 #define TEALET_TFLAGS_EXITED (1u << 3)
 #define TEALET_TFLAGS_MAIN_LINEAGE (1u << 4)
 #define TEALET_TFLAGS_FORK (1u << 5)
+#define TEALET_TFLAGS_EXITFORCE (1u << 6)
 
 /* Internal per-stack flags (stored in tealet_stack_t::flags). */
 #define TEALET_SFLAGS_DEFUNCT (1u << 0)
@@ -1060,7 +1061,7 @@ static int tealet_save_state(tealet_main_t *g_main, void *old_stack_pointer) {
   tealet_sub_t *g_target = g_main->g_target;
   tealet_sub_t *g_current = g_main->g_current;
   char *target_stop = g_target->stack_far;
-  int exiting, fail, fail_ok, auto_delete;
+  int exiting, force, fail, fail_ok, auto_delete;
 
   tealet_verify_current_matches_caller(g_current);
 
@@ -1068,12 +1069,12 @@ static int tealet_save_state(tealet_main_t *g_main, void *old_stack_pointer) {
   assert(g_current != g_target);
 
   exiting = ((g_current->flags & TEALET_TFLAGS_EXITING) != 0);
-  /* if task is exiting, failure cannot be signalled. the switch
-   * must proceed. A stack failing to get saved (due to memory shortage)
-   * with this flag set will be set as invalid, so that it cannot
-   * be switched back to again.
+  force = ((g_current->flags & TEALET_TFLAGS_EXITFORCE) != 0);
+  /* Force mode is used by tealet_exit() to request non-failable save
+   * behavior under memory pressure. A stack that cannot be saved may be
+   * marked defunct so the switch can proceed.
    */
-  fail_ok = !exiting;
+  fail_ok = !force;
 
   /* save and unlink older stacks on demand */
   /* when coming from unbounded stack, there should be no list of unsaved stacks
@@ -1094,7 +1095,7 @@ static int tealet_save_state(tealet_main_t *g_main, void *old_stack_pointer) {
     /* tealet is exiting. We don't save its stack. */
     assert(!TEALET_IS_MAIN((tealet_t *)g_current));
     auto_delete = ((g_current->flags & TEALET_TFLAGS_AUTODELETE) != 0);
-    g_current->flags &= ~(TEALET_TFLAGS_EXITING | TEALET_TFLAGS_AUTODELETE);
+    g_current->flags &= ~(TEALET_TFLAGS_EXITING | TEALET_TFLAGS_AUTODELETE | TEALET_TFLAGS_EXITFORCE);
     g_current->flags |= TEALET_TFLAGS_EXITED;
     if (auto_delete) {
       /* auto-delete the tealet */
@@ -1326,7 +1327,7 @@ static int tealet_switchstack(tealet_main_t *g_main, tealet_sub_t *target, void 
 #endif
 
   switch_result = (g_main->g_sw == SW_RESTORE ? 0 : 1);
-  if (g_main->g_current == (tealet_sub_t *)g_main && (g_main->g_flags & TEALET_MFLAGS_PANIC)) {
+  if (g_main->g_flags & TEALET_MFLAGS_PANIC) {
     g_main->g_flags &= ~TEALET_MFLAGS_PANIC;
     return TEALET_ERR_PANIC;
   }
@@ -1364,6 +1365,9 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
                               void **parg, void *stack_far) {
   int result;
   tealet_sub_t *g_exit_target;
+  int exit_flags;
+  void *exit_arg;
+  int retry_flags;
   int run_on_create = g_new == g_target; /* true for tealet_new(), we are switching to the new tealet */
   void *run_arg, *switch_arg;
   void *initial_run_arg;
@@ -1420,7 +1424,33 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
     tealet_unlock_switch(g_main);
     g_exit_target = (tealet_sub_t *)(run((tealet_t *)g_main->g_current, run_arg));
 
-    tealet_exit((tealet_t *)g_exit_target, NULL, TEALET_EXIT_DELETE);
+    /* Resolve any deferred-exit state explicitly so retries below use a
+     * single consistent (target,arg,flags) policy.
+     * Note: DEFER+FORCE is redundant in this implicit return path because a
+     * TEALET_ERR_MEM retry always adds FORCE anyway.
+     */
+    exit_flags = TEALET_EXIT_DELETE;
+    exit_arg = NULL;
+    if (g_main->g_flags & TEALET_EXIT_DEFER) {
+      exit_flags = g_main->g_flags & (~TEALET_EXIT_DEFER);
+      exit_arg = g_main->g_arg;
+      g_main->g_flags = 0;
+      g_main->g_arg = NULL;
+    }
+
+    /* Implicit return policy from run():
+     * 1) Try requested target in fail-fast mode.
+     * 2) If target is defunct, panic to main explicitly.
+     * 3) If memory blocked the transfer, retry requested target with FORCE.
+     */
+    result = tealet_exit((tealet_t *)g_exit_target, exit_arg, exit_flags);
+    if (result == TEALET_ERR_DEFUNCT) {
+      retry_flags = exit_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
+      (void)tealet_exit((tealet_t *)g_main, exit_arg, retry_flags);
+    } else if (result == TEALET_ERR_MEM) {
+      retry_flags = exit_flags | TEALET_EXIT_FORCE;
+      (void)tealet_exit((tealet_t *)g_exit_target, exit_arg, retry_flags);
+    }
     assert(!"This point should not be reached");
   } else {
     /* Either just a create, with no run, or a switch back
@@ -1698,6 +1728,8 @@ static int tealet_exit_inner(tealet_t *target, void *arg, int flags) {
     return -2; /* invalid tealet */
 
   g_current->flags |= TEALET_TFLAGS_EXITING;
+  if (flags & TEALET_EXIT_FORCE)
+    g_current->flags |= TEALET_TFLAGS_EXITFORCE;
   assert(g_current->stack == NULL);
   assert((g_current->flags & TEALET_TFLAGS_AUTODELETE) == 0);
   if (flags & TEALET_EXIT_DELETE)
@@ -1706,11 +1738,11 @@ static int tealet_exit_inner(tealet_t *target, void *arg, int flags) {
   assert(result < 0); /* only return here if there was failure */
   g_target->stack_far = stack_far;
   g_current->stack = NULL;
-  g_current->flags &= ~TEALET_TFLAGS_AUTODELETE;
+  g_current->flags &= ~(TEALET_TFLAGS_EXITING | TEALET_TFLAGS_AUTODELETE | TEALET_TFLAGS_EXITFORCE);
   return result;
 }
 
-/* Exit current tealet and transfer control.
+/* Exit current tealet and transfer control to requested target.
  *
  * Switching API lock policy:
  * all five switching APIs (`tealet_new()`, `tealet_create()`,
@@ -1721,7 +1753,16 @@ static int tealet_exit_inner(tealet_t *target, void *arg, int flags) {
 int tealet_exit(tealet_t *target, void *arg, int flags) {
   tealet_sub_t *g_target = (tealet_sub_t *)target;
   tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
+  int flags_used;
+  int panic_requested;
   int result;
+
+  if ((flags & ~(TEALET_EXIT_DELETE | TEALET_EXIT_DEFER | TEALET_EXIT_FORCE | TEALET_EXIT_PANIC)) != 0) {
+    return TEALET_ERR_INVAL;
+  }
+  if ((flags & TEALET_EXIT_DEFER) && (flags & TEALET_EXIT_PANIC)) {
+    return TEALET_ERR_INVAL;
+  }
 
   tealet_lock_switch(g_main);
   if (flags & TEALET_EXIT_DEFER) {
@@ -1744,18 +1785,19 @@ int tealet_exit(tealet_t *target, void *arg, int flags) {
     g_main->g_flags = 0;
     g_main->g_arg = 0;
   }
-  result = tealet_exit_inner(target, arg, flags);
-  assert(result < 0);
-  if (result == TEALET_ERR_DEFUNCT && !TEALET_IS_MAIN(target))
+  flags_used = flags;
+  panic_requested = ((flags_used & TEALET_EXIT_PANIC) != 0);
+  if (panic_requested)
     g_main->g_flags |= TEALET_MFLAGS_PANIC;
-  /* fallback: switch to main */
-  result = tealet_exit_inner(target->main, arg, flags);
-  (void)result;
-  /* Unreachable in normal operation: successful tealet_exit_inner() does not
-   * return to this frame. If control returns here, execution state is corrupt.
-   */
-  assert(0 && "unreachable tealet_exit return path");
-  abort();
+
+  result = tealet_exit_inner(target, arg, flags_used);
+  assert(result < 0);
+
+  if (panic_requested)
+    g_main->g_flags &= ~TEALET_MFLAGS_PANIC;
+
+  tealet_unlock_switch(g_main);
+  return result;
 }
 
 /* Fork the active tealet.

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -210,30 +210,32 @@ void tealet_finalize(tealet_t *tealet);
 /**
  * @brief Create a new tealet without starting it.
  * @param tealet Main/related tealet context used for allocation and ownership.
+ * @param pcreated Output pointer receiving the created tealet on success (must be non-NULL).
  * @param run Entry function for the created tealet.
  * @param stack_far Optional minimum far-boundary requirement for the initial stack snapshot.
- * @return New tealet pointer, or NULL on allocation/setup failure.
+ * @return 0 on success, negative #TEALET_ERR_* on failure.
  *
  * The new tealet enters execution when tealet_switch() first targets it.
  * If @p stack_far is non-NULL, capture range is only extended (never shrunk)
  * relative to the default internally selected boundary.
  */
 TEALET_API
-tealet_t *tealet_create(tealet_t *tealet, tealet_run_t run, void *stack_far);
+int tealet_create(tealet_t *tealet, tealet_t **pcreated, tealet_run_t run, void *stack_far);
 
 /**
  * @brief Create and immediately start a new tealet.
  * @param tealet Main/related tealet context.
+ * @param pcreated Optional output pointer receiving the created tealet on success; may be NULL.
  * @param run Entry function.
  * @param parg In/out switch argument pointer (same semantics as tealet_switch()).
  * @param stack_far Optional minimum far-boundary requirement for the initial stack snapshot.
- * @return New tealet pointer on success; NULL on allocation/switch failure.
+ * @return 0 on success, negative #TEALET_ERR_* on failure.
  *
  * Semantically equivalent to tealet_create() followed by tealet_switch(),
  * but performed as one operation.
  */
 TEALET_API
-tealet_t *tealet_new(tealet_t *tealet, tealet_run_t run, void **parg, void *stack_far);
+int tealet_new(tealet_t *tealet, tealet_t **pcreated, tealet_run_t run, void **parg, void *stack_far);
 
 /**
  * @brief Suspend current tealet and resume @p target.
@@ -753,14 +755,15 @@ void *tealet_stack_further(void *a, void *b);
  * @param dummy1 Matches tealet_new() signature; ignored.
  * @param dummy2 Matches tealet_new() signature; ignored.
  * @param dummy3 Matches tealet_new() signature; ignored.
- * @param dummy4 Optional requested boundary (as in tealet_new()).
+ * @param dummy4 Matches tealet_new() signature; ignored.
+ * @param dummy5 Optional requested boundary (as in tealet_new()).
  * @return Effective far boundary that tealet_new() would use at this stack depth.
  *
  * this is used to get the "far" address if a tealet were initialized here.
  * The arguments must match tealet_new(); they are only dummies.
  */
 TEALET_API
-void *tealet_new_probe(tealet_t *dummy1, tealet_run_t dummy2, void **dummy3, void *dummy4);
+void *tealet_new_probe(tealet_t *dummy1, tealet_t **dummy2, tealet_run_t dummy3, void **dummy4, void *dummy5);
 
 /* Convenience macros */
 #define TEALET_MAIN(t) ((t)->main)

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -225,7 +225,7 @@ int tealet_create(tealet_t *tealet, tealet_t **pcreated, tealet_run_t run, void 
 /**
  * @brief Create and immediately start a new tealet.
  * @param tealet Main/related tealet context.
- * @param pcreated Optional output pointer receiving the created tealet on success; may be NULL.
+ * @param pcreated Optional output pointer receiving the created tealet pointer; may be NULL.
  * @param run Entry function.
  * @param parg In/out switch argument pointer (same semantics as tealet_switch()).
  * @param stack_far Optional minimum far-boundary requirement for the initial stack snapshot.
@@ -233,6 +233,11 @@ int tealet_create(tealet_t *tealet, tealet_t **pcreated, tealet_run_t run, void 
  *
  * Semantically equivalent to tealet_create() followed by tealet_switch(),
  * but performed as one operation.
+ *
+ * On successful return, a value written to @p pcreated is not guaranteed to
+ * remain valid: the new tealet may have already run and been deleted before
+ * tealet_new() returns (for example via return, tealet_exit(..., DELETE), or
+ * another deletion path).
  */
 TEALET_API
 int tealet_new(tealet_t *tealet, tealet_t **pcreated, tealet_run_t run, void **parg, void *stack_far);

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -251,6 +251,8 @@ int tealet_new(tealet_t *tealet, tealet_t **pcreated, tealet_run_t run, void **p
  *
  * With #TEALET_SWITCH_FORCE, save-time memory failures may defunct
  * intermediate non-main saved stacks to complete the requested transfer.
+ * #TEALET_ERR_MEM can still be returned with FORCE when only main-stack
+ * growth would allow progress, because main is never marked defunct.
  *
  * #TEALET_SWITCH_PANIC requests panic delivery to the receiving tealet as
  * #TEALET_ERR_PANIC on its resumed switch return path.
@@ -283,13 +285,16 @@ int tealet_switch(tealet_t *target, void **parg, int flags);
  * Without #TEALET_EXIT_FORCE, memory pressure while saving state returns #TEALET_ERR_MEM.
  * With #TEALET_EXIT_FORCE, save-time memory failures may defunct intermediate stacks
  * to complete the requested transfer.
+ * #TEALET_ERR_MEM can still be returned with FORCE when only main-stack
+ * growth would allow progress, because main is never marked defunct.
  *
  * #TEALET_EXIT_PANIC requests panic delivery to the receiving tealet as
  * #TEALET_ERR_PANIC on its resumed switch return path. It is invalid with
  * #TEALET_EXIT_DEFER.
  *
- * `return p;` from run() uses libtealet's implicit exit policy rooted in
- * `tealet_exit(p, NULL, TEALET_EXIT_DELETE)`.
+ * `return p;` from run() uses an implicit policy rooted in
+ * `tealet_exit(p, NULL, TEALET_EXIT_DELETE)`, with retries for memory/defunct
+ * failures and a panic+force fallback to main.
  */
 TEALET_API
 int tealet_exit(tealet_t *target, void *arg, int flags);

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -241,16 +241,29 @@ int tealet_new(tealet_t *tealet, tealet_t **pcreated, tealet_run_t run, void **p
  * @brief Suspend current tealet and resume @p target.
  * @param target Tealet to switch to; must share the same main tealet and thread.
  * @param parg In/out argument pointer passed across switches; may be NULL.
+ * @param flags Switch behavior bits: #TEALET_SWITCH_DEFAULT, #TEALET_SWITCH_FORCE,
+ * #TEALET_SWITCH_PANIC.
  * @retval 0 Success.
  * @retval TEALET_ERR_MEM Save/restore failed due to memory pressure.
  * @retval TEALET_ERR_DEFUNCT Target tealet/stack is defunct.
- * @retval TEALET_ERR_PANIC Resumed due to panic-tagged tealet_exit() transfer.
+ * @retval TEALET_ERR_PANIC Resumed due to panic-tagged transfer.
  * @retval TEALET_ERR_INVAL Invalid state/target.
+ *
+ * With #TEALET_SWITCH_FORCE, save-time memory failures may defunct
+ * intermediate non-main saved stacks to complete the requested transfer.
+ *
+ * #TEALET_SWITCH_PANIC requests panic delivery to the receiving tealet as
+ * #TEALET_ERR_PANIC on its resumed switch return path.
  *
  * @warning Do not pass stack-allocated cross-tealet payloads through @p parg.
  */
 TEALET_API
-int tealet_switch(tealet_t *target, void **parg);
+int tealet_switch(tealet_t *target, void **parg, int flags);
+
+/* Switch flags */
+#define TEALET_SWITCH_DEFAULT 0 /* default switch behavior */
+#define TEALET_SWITCH_FORCE 4   /* force switch despite save-time memory failures */
+#define TEALET_SWITCH_PANIC 8   /* mark the receiving tealet as panic-resumed */
 
 /* Exit flags */
 #define TEALET_EXIT_DEFAULT 0 /* Don't auto-delete */
@@ -363,7 +376,7 @@ int tealet_exit(tealet_t *target, void *arg, int flags);
  *   } else if (result > 0) {
  *       // This is the parent tealet
  *       // ... parent-specific code ...
- *       tealet_switch(child, &arg); // Switch to child when ready
+ *       tealet_switch(child, &arg, TEALET_SWITCH_DEFAULT); // Switch to child when ready
  *   } else {
  *       // Error occurred (result < 0)
  *   }

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -125,7 +125,7 @@ typedef tealet_t *(*tealet_run_t)(tealet_t *current, void *arg);
                                  */
 #define TEALET_ERR_INVAL -4     /* invalid argument */
 #define TEALET_ERR_INTEGRITY -5 /* current tealet violated stack-integrity boundary */
-#define TEALET_ERR_PANIC -6     /* switched to main due to panic reroute from tealet_exit() */
+#define TEALET_ERR_PANIC -6     /* receiver resumed with explicit panic exit signal */
 
 /* configuration API structure versioning */
 #define TEALET_CONFIG_VERSION_1 1
@@ -242,7 +242,7 @@ tealet_t *tealet_new(tealet_t *tealet, tealet_run_t run, void **parg, void *stac
  * @retval 0 Success.
  * @retval TEALET_ERR_MEM Save/restore failed due to memory pressure.
  * @retval TEALET_ERR_DEFUNCT Target tealet/stack is defunct.
- * @retval TEALET_ERR_PANIC Returned to main after panic reroute from tealet_exit().
+ * @retval TEALET_ERR_PANIC Resumed due to panic-tagged tealet_exit() transfer.
  * @retval TEALET_ERR_INVAL Invalid state/target.
  *
  * @warning Do not pass stack-allocated cross-tealet payloads through @p parg.
@@ -254,16 +254,27 @@ int tealet_switch(tealet_t *target, void **parg);
 #define TEALET_EXIT_DEFAULT 0 /* Don't auto-delete */
 #define TEALET_EXIT_DELETE 1  /* Auto-delete on exit */
 #define TEALET_EXIT_DEFER 2   /* Defer exit to return statement */
+#define TEALET_EXIT_FORCE 4   /* Force exit switch despite save-time memory failures */
+#define TEALET_EXIT_PANIC 8   /* Mark the receiving tealet as panic-resumed */
 
 /**
  * @brief Exit current tealet and transfer control to @p target.
  * @param target Requested target tealet.
  * @param arg Optional argument to deliver to @p target.
- * @param flags Exit behavior bits: #TEALET_EXIT_DEFAULT, #TEALET_EXIT_DELETE, #TEALET_EXIT_DEFER.
- * @return 0 only for deferred setup path; otherwise this call is non-returning on success.
+ * @param flags Exit behavior bits: #TEALET_EXIT_DEFAULT, #TEALET_EXIT_DELETE,
+ * #TEALET_EXIT_DEFER, #TEALET_EXIT_FORCE, #TEALET_EXIT_PANIC.
+ * @return 0 only for deferred setup path; otherwise returns a negative error code if transfer cannot start.
  *
- * If the requested target is defunct, control is rerouted to main as panic fallback.
- * `return p;` from run() is equivalent to `tealet_exit(p, NULL, TEALET_EXIT_DELETE)`.
+ * Without #TEALET_EXIT_FORCE, memory pressure while saving state returns #TEALET_ERR_MEM.
+ * With #TEALET_EXIT_FORCE, save-time memory failures may defunct intermediate stacks
+ * to complete the requested transfer.
+ *
+ * #TEALET_EXIT_PANIC requests panic delivery to the receiving tealet as
+ * #TEALET_ERR_PANIC on its resumed switch return path. It is invalid with
+ * #TEALET_EXIT_DEFER.
+ *
+ * `return p;` from run() uses libtealet's implicit exit policy rooted in
+ * `tealet_exit(p, NULL, TEALET_EXIT_DELETE)`.
  */
 TEALET_API
 int tealet_exit(tealet_t *target, void *arg, int flags);

--- a/src/tealet_extras.c
+++ b/src/tealet_extras.c
@@ -63,7 +63,9 @@ static tealet_t *_tealet_stub_main(tealet_t *current, void *arg) {
 }
 
 /* create a stub and return it */
-tealet_t *tealet_stub_new(tealet_t *t, void *stack_far) { return tealet_create(t, _tealet_stub_main, stack_far); }
+int tealet_stub_new(tealet_t *t, tealet_t **pstub, void *stack_far) {
+  return tealet_create(t, pstub, _tealet_stub_main, stack_far);
+}
 
 /*
  * Run a stub.

--- a/src/tealet_extras.c
+++ b/src/tealet_extras.c
@@ -83,7 +83,7 @@ int tealet_stub_run(tealet_t *stub, tealet_run_t run, void **parg) {
   psarg->run = run;
   psarg->runarg = parg ? *parg : NULL;
   myarg = (void *)psarg;
-  result = tealet_switch(stub, &myarg);
+  result = tealet_switch(stub, &myarg, TEALET_SWITCH_DEFAULT);
   if (result) {
     /* failure */
     tealet_free(stub, psarg);

--- a/src/tealet_extras.h
+++ b/src/tealet_extras.h
@@ -28,9 +28,9 @@ void tealet_statsalloc_init(tealet_statsalloc_t *alloc, tealet_alloc_t *base);
  * position on the stack.
  */
 
-/* create a stub and return it */
+/* create a stub and return it via out-parameter */
 TEALET_API
-tealet_t *tealet_stub_new(tealet_t *tealet, void *stack_far);
+int tealet_stub_new(tealet_t *tealet, tealet_t **pstub, void *stack_far);
 
 /*
  * Run a previously created stub.

--- a/src/tools.c
+++ b/src/tools.c
@@ -63,7 +63,9 @@ static tealet_t *_tealet_stub_main(tealet_t *current, void *arg) {
 }
 
 /* create a stub and return it */
-tealet_t *tealet_stub_new(tealet_t *t, void *stack_far) { return tealet_create(t, _tealet_stub_main, stack_far); }
+int tealet_stub_new(tealet_t *t, tealet_t **pstub, void *stack_far) {
+  return tealet_create(t, pstub, _tealet_stub_main, stack_far);
+}
 
 /*
  * Run a stub.

--- a/src/tools.c
+++ b/src/tools.c
@@ -83,7 +83,7 @@ int tealet_stub_run(tealet_t *stub, tealet_run_t run, void **parg) {
   psarg->run = run;
   psarg->runarg = parg ? *parg : NULL;
   myarg = (void *)psarg;
-  result = tealet_switch(stub, &myarg);
+  result = tealet_switch(stub, &myarg, TEALET_SWITCH_DEFAULT);
   if (result) {
     /* failure */
     tealet_free(stub, psarg);

--- a/tests/setcontext.c
+++ b/tests/setcontext.c
@@ -29,7 +29,7 @@ tealet_t *loop_func(tealet_t *current, void *arg) {
     void *value = (void *)(intptr_t)i;
 
     /* Switch to main tealet */
-    tealet_switch(tealet_previous(current), &value);
+    tealet_switch(tealet_previous(current), &value, TEALET_SWITCH_DEFAULT);
     tealet_test_lock_assert_unheld(&g_lock_state);
     /* after switch, any void* passed _to_ us is in 'value' */
   }
@@ -73,7 +73,7 @@ int main(void) {
      * only retrieve the result
      */
     printf("%d\n", (int)(intptr_t)data);
-    tealet_switch(loop, &data);
+    tealet_switch(loop, &data, TEALET_SWITCH_DEFAULT);
   }
   tealet_delete(loop);
   tealet_test_lock_assert_balanced(&g_lock_state);

--- a/tests/setcontext.c
+++ b/tests/setcontext.c
@@ -60,7 +60,12 @@ int main(void) {
 
   /* how many rounds? */
   data = (void *)10;
-  loop = tealet_new(tmain, loop_func, &data, NULL);
+  loop = NULL;
+  if (tealet_new(tmain, &loop, loop_func, &data, NULL) != 0) {
+    tealet_test_lock_assert_balanced(&g_lock_state);
+    tealet_finalize(tmain);
+    return 1;
+  }
 
   /* loop until the tealet has exited */
   while (tealet_status(loop) == TEALET_STATUS_ACTIVE) {

--- a/tests/test_chunks.c
+++ b/tests/test_chunks.c
@@ -74,8 +74,8 @@ int main(void) {
 
   /* Create and run a tealet to build up its stack with multiple chunks */
   printf("1. Creating tealet and forcing stack growth into multiple chunks...\n");
-  t1 = tealet_new(g_main, worker_run, NULL, NULL);
-  if (!t1) {
+  t1 = NULL;
+  if (tealet_new(g_main, &t1, worker_run, NULL, NULL) != 0) {
     fprintf(stderr, "Failed to create tealet\n");
     tealet_test_lock_assert_balanced(&g_lock_state);
     tealet_finalize(g_main);

--- a/tests/test_chunks.c
+++ b/tests/test_chunks.c
@@ -43,7 +43,7 @@ static tealet_t *worker_run(tealet_t *t, void *arg) {
     consume_stack(depth, buffer);
 
   /* Yield back to main */
-  tealet_switch(g_main, NULL);
+  tealet_switch(g_main, NULL, TEALET_SWITCH_DEFAULT);
 
   tealet_test_lock_assert_unheld(&g_lock_state);
 
@@ -83,9 +83,9 @@ int main(void) {
   }
 
   /* Switch to it a few times to build up stack */
-  tealet_switch(t1, NULL);
-  tealet_switch(t1, NULL);
-  tealet_switch(t1, NULL);
+  tealet_switch(t1, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(t1, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(t1, NULL, TEALET_SWITCH_DEFAULT);
 
   /* Now t1 has a saved stack with multiple chunks */
   tealet_get_stats(g_main, &stats);

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -117,13 +117,13 @@ static tealet_t *run_write_to_target(tealet_t *current, void *arg) {
   original = *target;
   *target ^= 0x5Au;
 
-  switch_result = tealet_switch(command->return_to, NULL);
+  switch_result = tealet_switch(command->return_to, NULL, TEALET_SWITCH_DEFAULT);
   if (command->first_switch_result)
     *command->first_switch_result = switch_result;
 
   if (switch_result == TEALET_ERR_INTEGRITY) {
     *target = original;
-    switch_result = tealet_switch(command->return_to, NULL);
+    switch_result = tealet_switch(command->return_to, NULL, TEALET_SWITCH_DEFAULT);
   }
 
   if (command->recovery_switch_result)
@@ -265,13 +265,13 @@ static tealet_t *run_write_with_mprotect_split(tealet_t *current, void *arg) {
   original = *target;
   *target ^= 0x5Au;
 
-  switch_result = tealet_switch(command->return_to, NULL);
+  switch_result = tealet_switch(command->return_to, NULL, TEALET_SWITCH_DEFAULT);
   if (command->first_switch_result)
     *command->first_switch_result = switch_result;
 
   if (switch_result == TEALET_ERR_INTEGRITY) {
     *target = original;
-    switch_result = tealet_switch(command->return_to, NULL);
+    switch_result = tealet_switch(command->return_to, NULL, TEALET_SWITCH_DEFAULT);
   }
 
   if (command->recovery_switch_result)
@@ -329,7 +329,7 @@ static int run_integrity_switch_case(int fail_policy, int write_inside, int *fir
   command->recovery_switch_result = &second_switch_result;
 
   arg = command;
-  result = tealet_switch(writer, &arg);
+  result = tealet_switch(writer, &arg, TEALET_SWITCH_DEFAULT);
   assert(result == 0);
   tealet_free(main_tealet, outside_target);
   tealet_free(main_tealet, command);
@@ -395,7 +395,7 @@ static int run_mprotect_split_case(int write_guard_page, int *first_result, int 
   command->recovery_switch_result = &second_switch_result;
 
   arg = command;
-  result = tealet_switch(writer, &arg);
+  result = tealet_switch(writer, &arg, TEALET_SWITCH_DEFAULT);
   if (write_guard_page) {
     if (first_result)
       *first_result = first_switch_result;
@@ -593,7 +593,7 @@ static void test_set_while_snapshot_active_resizes(void) {
   assert(worker != NULL);
 
   arg = command;
-  result = tealet_switch(worker, &arg);
+  result = tealet_switch(worker, &arg, TEALET_SWITCH_DEFAULT);
   assert(result == 0);
   assert(command->configure_result == 0);
 

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -315,7 +315,9 @@ static int run_integrity_switch_case(int fail_policy, int write_inside, int *fir
   assert((cfg.flags & TEALET_CONFIGF_STACK_INTEGRITY) != 0);
   assert((cfg.flags & TEALET_CONFIGF_STACK_SNAPSHOT) != 0);
 
-  writer = tealet_create(main_tealet, run_write_to_target, NULL);
+  writer = NULL;
+  result = tealet_create(main_tealet, &writer, run_write_to_target, NULL);
+  assert(result == 0);
   assert(writer != NULL);
 
   first_switch_result = 0;
@@ -379,7 +381,9 @@ static int run_mprotect_split_case(int write_guard_page, int *first_result, int 
   assert((cfg.flags & TEALET_CONFIGF_STACK_SNAPSHOT) != 0);
   assert((cfg.flags & TEALET_CONFIGF_STACK_GUARD) != 0);
 
-  writer = tealet_create(main_tealet, run_write_with_mprotect_split, NULL);
+  writer = NULL;
+  result = tealet_create(main_tealet, &writer, run_write_with_mprotect_split, NULL);
+  assert(result == 0);
   assert(writer != NULL);
 
   first_switch_result = 0;
@@ -583,7 +587,9 @@ static void test_set_while_snapshot_active_resizes(void) {
   command->return_to = main_tealet;
   command->configure_result = TEALET_ERR_MEM;
 
-  worker = tealet_create(main_tealet, run_resize_snapshot_while_active, NULL);
+  worker = NULL;
+  result = tealet_create(main_tealet, &worker, run_resize_snapshot_while_active, NULL);
+  assert(result == 0);
   assert(worker != NULL);
 
   arg = command;

--- a/tests/test_fork.c
+++ b/tests/test_fork.c
@@ -499,7 +499,7 @@ static void test_new_previous(void *far_marker) {
 
   /* Test tealet_new() from main */
   arg = main;
-  tealet_new(main, test_new_previous_run, &arg, NULL);
+  assert(tealet_new(main, NULL, test_new_previous_run, &arg, NULL) == 0);
 
   /* Verify tealet_previous() after return from tealet_new() */
   /* Note: the tealet has already been freed at this point, so we just verify

--- a/tests/test_fork.c
+++ b/tests/test_fork.c
@@ -85,7 +85,7 @@ static void test_basic_fork(void *far_marker) {
     printf("  Parent: switching to child...\n");
 
     /* Switch to child */
-    result = tealet_switch(other, NULL);
+    result = tealet_switch(other, NULL, TEALET_SWITCH_DEFAULT);
     assert(result == 0);
     assert(testvalue == 0); /* Parent value should be preserved after child modifies it */
 
@@ -243,13 +243,13 @@ static void test_multiple_forks(void *far_marker) {
   /* Switch to child1 */
   visited++;
   printf("  Parent: switching to child1 (visited=%d)\n", visited);
-  tealet_switch(child1, NULL);
+  tealet_switch(child1, NULL, TEALET_SWITCH_DEFAULT);
   printf("  Parent: returned from child1\n");
 
   /* Switch to child2 */
   visited++;
   printf("  Parent: switching to child2 (visited=%d)\n", visited);
-  tealet_switch(child2, NULL);
+  tealet_switch(child2, NULL, TEALET_SWITCH_DEFAULT);
   printf("  Parent: returned from child2\n");
 
   assert(visited == 2);
@@ -293,7 +293,7 @@ static void test_fork_switch_arg(void *far_marker) {
     /* Switch back to parent with a value */
     childarg = (void *)0x12345678;
     printf("  Child: started.switching back with value %p\n", childarg);
-    tealet_switch(other, &childarg);
+    tealet_switch(other, &childarg, TEALET_SWITCH_DEFAULT);
     /* parent switched back, arg should be updated */
     assert(childarg == (void *)0xdeadbeef);
     printf("  Child: switched back from parent with arg=%p\n", childarg);
@@ -314,7 +314,7 @@ static void test_fork_switch_arg(void *far_marker) {
     parentarg = (void *)0xdeadbeef;
     /* switch back to child with a different arg, for the child to exit*/
     printf("  Parent: switching back to child with arg=%p\n", parentarg);
-    result = tealet_switch(other, &parentarg);
+    result = tealet_switch(other, &parentarg, TEALET_SWITCH_DEFAULT);
     printf("  Parent: returned from child switch, arg=%p, result=%d\n", parentarg, result);
     /* child should have exited, and passed the final arg to us*/
     assert(result == 0);
@@ -358,7 +358,7 @@ static void test_fork_default_arg(void *far_marker) {
 
     /* Switch to child with a value */
     parentarg = (void *)0xABCDEF00;
-    result = tealet_switch(child, &parentarg);
+    result = tealet_switch(child, &parentarg, TEALET_SWITCH_DEFAULT);
     assert(result == 0);
 
     /* Child should have switched back with a different value */
@@ -381,7 +381,7 @@ static void test_fork_default_arg(void *far_marker) {
 
     /* Switch back to parent with a different value */
     childarg = (void *)0xDEADBEEF;
-    tealet_switch(child, &childarg); /* child pointer is parent from child's perspective */
+    tealet_switch(child, &childarg, TEALET_SWITCH_DEFAULT); /* child pointer is parent from child's perspective */
 
     printf("  Child: this should never print\n");
     assert(0);
@@ -427,7 +427,7 @@ static void test_ping_pong(void *far_marker) {
 
     /* Ping-pong a few times */
     while (counter <= 5) {
-      tealet_switch(child_saved, NULL);
+      tealet_switch(child_saved, NULL, TEALET_SWITCH_DEFAULT);
       counter++;
       /* Parent increments by 1 each iteration (but only first 4) */
       if (counter <= 5) {
@@ -459,7 +459,7 @@ static void test_ping_pong(void *far_marker) {
       /* Child increments by 10 each iteration (counter goes 1,2,3,4 -> indices
        * 0,1,2,3) */
       data[counter - 1] += 10;
-      tealet_switch(child, NULL); /* child pointer is parent from child's perspective */
+      tealet_switch(child, NULL, TEALET_SWITCH_DEFAULT); /* child pointer is parent from child's perspective */
       counter++;
       printf("  Child: counter=%d, data=[%d,%d,%d,%d,%d], switching to parent\n", counter, data[0], data[1], data[2],
              data[3], data[4]);

--- a/tests/test_stochastic.c
+++ b/tests/test_stochastic.c
@@ -151,7 +151,7 @@ static int worker_recursive(tealet_t *current, int depth) {
       } else {
         /* Immediate exit: child tealets switch to main, main unwinds */
         if (current != g_main) {
-          tealet_switch(g_main, NULL);
+          tealet_switch(g_main, NULL, TEALET_SWITCH_DEFAULT);
           /* we should not resume this */
           assert(0);
         }
@@ -178,7 +178,7 @@ static int worker_recursive(tealet_t *current, int depth) {
       /* Switch to another tealet */
       target = pick_random_tealet(current);
       if (target) {
-        tealet_switch(target, NULL);
+        tealet_switch(target, NULL, TEALET_SWITCH_DEFAULT);
       }
       continue;
 
@@ -207,7 +207,7 @@ static int worker_recursive(tealet_t *current, int depth) {
         /* Switch to a random tealet */
         target = pick_random_tealet(current);
         if (target) {
-          tealet_switch(target, NULL);
+          tealet_switch(target, NULL, TEALET_SWITCH_DEFAULT);
         }
         /* We shouldn't resume here - we've exited */
         assert(0);
@@ -351,7 +351,7 @@ int main(int argc, char *argv[]) {
           if (g_verbose) {
             printf("  Switching to tealet %d to unwind\n", i);
           }
-          tealet_switch(g_tealets[i], NULL);
+          tealet_switch(g_tealets[i], NULL, TEALET_SWITCH_DEFAULT);
         }
       }
     }

--- a/tests/test_stochastic.c
+++ b/tests/test_stochastic.c
@@ -185,7 +185,7 @@ static int worker_recursive(tealet_t *current, int depth) {
     } else if (choice == 3 && g_tealet_count < MAX_TEALETS) {
       /* Create new tealet at current stack depth */
       void *arg = NULL;
-      tealet_new(current, worker_entry, &arg, NULL);
+      (void)tealet_new(current, NULL, worker_entry, &arg, NULL);
       continue;
 
     } else if (choice == 4 && current != g_main && g_tealet_count >= MAX_TEALETS) {

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -241,6 +241,7 @@ static tealet_t *tealet_new_x(tealet_t *m, tealet_run_t run, void **parg) {
 
 /* create a tealet or stub low on the stack */
 static tealet_t *tealet_new_descend(tealet_t *t, int level, tealet_run_t run, void **parg) {
+  tealet_t *stub;
   int boo[10];
   boo[9] = 0;
   (void)boo;
@@ -248,8 +249,9 @@ static tealet_t *tealet_new_descend(tealet_t *t, int level, tealet_run_t run, vo
     return tealet_new_descend(t, level - 1, run, parg);
   if (run)
     return tealet_new_x(t, run, parg);
-  else
-    return tealet_stub_new(t, NULL);
+  if (tealet_stub_new(t, &stub, NULL) != 0)
+    return NULL;
+  return stub;
 }
 
 /***************************************
@@ -563,7 +565,8 @@ void test_lock_transitions_stub(void) {
   init_test();
 
   lock_snapshot_take(&g_lock_stub_new_before);
-  stub = tealet_stub_new(g_main, NULL);
+  result = tealet_stub_new(g_main, &stub, NULL);
+  assert(result == 0);
   assert(stub != NULL);
   lock_snapshot_assert_delta_one(&g_lock_stub_new_before);
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -238,7 +238,7 @@ static tealet_t *tealet_new_x(tealet_t *m, tealet_run_t run, void **parg) {
   rc = tealet_create(m, &r, run, NULL);
   if (rc != 0)
     return NULL;
-  i = tealet_switch(r, parg);
+  i = tealet_switch(r, parg, TEALET_SWITCH_DEFAULT);
   if (i != 0) {
     tealet_delete(r);
     return 0;
@@ -388,7 +388,7 @@ static tealet_t *test_stack_far_isolation_run(tealet_t *current, void *arg) {
   assert(current != run_arg->main);
   assert(run_arg->shared->value == run_arg->before);
   run_arg->shared->value = run_arg->after;
-  tealet_switch(run_arg->main, NULL);
+  tealet_switch(run_arg->main, NULL, TEALET_SWITCH_DEFAULT);
   assert(run_arg->shared->value == run_arg->after);
   return run_arg->main;
 }
@@ -417,7 +417,7 @@ static tealet_t *test_stack_far_isolation_parent(tealet_t *current, void *arg) {
   /* Child wrote to its own copied stack, parent value remains unchanged. */
   assert(shared.value == 11);
 
-  tealet_switch(child, NULL);
+  tealet_switch(child, NULL, TEALET_SWITCH_DEFAULT);
 
   /* Child still observes its own modified value on resume. */
   assert(shared.value == 11);
@@ -520,7 +520,7 @@ static tealet_t *test_lock_transition_run(tealet_t *current, void *arg) {
   lock_snapshot_assert_delta_one(&g_lock_new_before);
 
   g_lock_phase = LOCK_PHASE_WAIT_RESUME;
-  tealet_switch(g_main, NULL);
+  tealet_switch(g_main, NULL, TEALET_SWITCH_DEFAULT);
 
   tealet_test_lock_assert_unheld(&g_lock_state);
   assert(g_lock_phase == LOCK_PHASE_SWITCH_RESUME);
@@ -548,7 +548,7 @@ void test_lock_transitions(void) {
 
   lock_snapshot_take(&g_lock_switch_before);
   g_lock_phase = LOCK_PHASE_SWITCH_RESUME;
-  result = tealet_switch(t, NULL);
+  result = tealet_switch(t, NULL, TEALET_SWITCH_DEFAULT);
   assert(result == 0);
   assert(g_lock_phase == LOCK_PHASE_DONE);
 
@@ -640,7 +640,7 @@ void test_simple_create_and_run(void) {
   init_test();
   t = NULL;
   assert(tealet_create(g_main, &t, test_simple_run, NULL) == 0);
-  tealet_switch(t, NULL);
+  tealet_switch(t, NULL, TEALET_SWITCH_DEFAULT);
   assert(status == 1);
   assert(tealet_previous(g_main) == NULL);
   fini_test();
@@ -663,7 +663,7 @@ void test_create_previous(void) {
   assert(tealet_create(g_main, &t, test_create_previous_run, NULL) == 0);
   assert(status == 0);
   /* Now switch to it - it should see main as previous */
-  tealet_switch(t, NULL);
+  tealet_switch(t, NULL, TEALET_SWITCH_DEFAULT);
   assert(status == 42); /* Verify it ran */
   assert(tealet_previous(g_main) == NULL);
   fini_test();
@@ -671,7 +671,7 @@ void test_create_previous(void) {
 
 static tealet_t *test_previous_manual_delete_run(tealet_t *t1, void *arg) {
   (void)arg;
-  tealet_switch(t1->main, NULL);
+  tealet_switch(t1->main, NULL, TEALET_SWITCH_DEFAULT);
   return t1->main;
 }
 
@@ -683,7 +683,7 @@ void test_previous_cleared_on_manual_delete(void) {
   assert(tealet_create(g_main, &t, test_previous_manual_delete_run, NULL) == 0);
   assert(t != NULL);
 
-  tealet_switch(t, NULL);
+  tealet_switch(t, NULL, TEALET_SWITCH_DEFAULT);
   assert(tealet_previous(g_main) == t);
 
   tealet_delete(t);
@@ -757,16 +757,16 @@ tealet_t *test_switch_2(tealet_t *t2, void *arg) {
   assert(status == 1);
   status = 2;
   assert(tealet_current(g_main) == t2);
-  tealet_switch(glob_t1, NULL);
+  tealet_switch(glob_t1, NULL, TEALET_SWITCH_DEFAULT);
   assert(status == 3);
   status = 4;
   assert(tealet_current(g_main) == t2);
-  tealet_switch(glob_t1, NULL);
+  tealet_switch(glob_t1, NULL, TEALET_SWITCH_DEFAULT);
   assert(status == 5);
   status = 6;
   assert(t2 == glob_t2);
   assert(tealet_current(g_main) == t2);
-  tealet_switch(t2, NULL);
+  tealet_switch(t2, NULL, TEALET_SWITCH_DEFAULT);
   assert(status == 6);
   status = 7;
   assert(tealet_current(g_main) == t2);
@@ -783,7 +783,7 @@ tealet_t *test_switch_1(tealet_t *t1, void *arg) {
   assert(status == 2);
   status = 3;
   assert(tealet_current(g_main) == t1);
-  tealet_switch(glob_t2, NULL);
+  tealet_switch(glob_t2, NULL, TEALET_SWITCH_DEFAULT);
   assert(status == 4);
   status = 5;
   assert(tealet_current(g_main) == t1);
@@ -805,7 +805,7 @@ tealet_t *test_switch_new_1(tealet_t *t1, void *arg) {
   tealet_t *caller = (tealet_t *)arg;
   tealet_t *stub;
   /* switch back to the creator */
-  tealet_switch(caller, NULL);
+  tealet_switch(caller, NULL, TEALET_SWITCH_DEFAULT);
   /* now we want to trample the stack */
   stub = tealet_new_descend(t1, 50, NULL, NULL);
   tealet_delete(stub);
@@ -817,7 +817,7 @@ tealet_t *test_switch_new_2(tealet_t *t2, void *arg) {
   tealet_t *target = (tealet_t *)arg;
   /* switch to tealet 1 to trample the stack*/
   target->extra = (void *)t2;
-  tealet_switch(target, NULL);
+  tealet_switch(target, NULL, TEALET_SWITCH_DEFAULT);
 
   /* and then return to main */
   return g_main;
@@ -833,7 +833,7 @@ void test_switch_new(void) {
   arg = (void *)tealet1;
   tealet2 = tealet_new_descend(g_main, 4, test_switch_new_2, &arg);
   assert(tealet_status(tealet2) == TEALET_STATUS_ACTIVE);
-  tealet_switch(tealet2, NULL);
+  tealet_switch(tealet2, NULL, TEALET_SWITCH_DEFAULT);
   /* tealet should be dead now */
   fini_test();
 }
@@ -845,7 +845,7 @@ tealet_t *test_arg_1(tealet_t *t1, void *arg) {
   void *myarg;
   tealet_t *peer = (tealet_t *)arg;
   myarg = (void *)1;
-  tealet_switch(peer, &myarg);
+  tealet_switch(peer, &myarg, TEALET_SWITCH_DEFAULT);
   assert(myarg == (void *)2);
   myarg = (void *)3;
   tealet_exit(peer, myarg, TEALET_EXIT_DELETE);
@@ -860,7 +860,7 @@ void test_arg(void) {
   t1 = tealet_new(g_main, test_arg_1, &myarg, NULL);
   assert(myarg == (void *)1);
   myarg = (void *)2;
-  tealet_switch(t1, &myarg);
+  tealet_switch(t1, &myarg, TEALET_SWITCH_DEFAULT);
   assert(myarg == (void *)3);
   fini_test();
 }
@@ -898,7 +898,7 @@ static void random_run(int index) {
       arg = (void *)(intptr_t)i;
       tealet_new(g_main, random_new_tealet, &arg, NULL);
     } else {
-      tealet_switch(tealetarray[i], NULL);
+      tealet_switch(tealetarray[i], NULL, TEALET_SWITCH_DEFAULT);
     }
     assert(status >= prevstatus);
     assert(tealet_current(g_main) == cur);
@@ -985,7 +985,7 @@ int random2_descend(int index, int level) {
     if (tealetarray[target] == NULL)
       random2_new(target);
     else
-      tealet_switch(tealetarray[target], NULL);
+      tealet_switch(tealetarray[target], NULL, TEALET_SWITCH_DEFAULT);
     return 1;
   } else {
     /* find a telet */
@@ -994,7 +994,7 @@ int random2_descend(int index, int level) {
       int k = (j + target) % ARRAYSIZE;
       if (k != index && tealetarray[k]) {
         status += 1;
-        tealet_switch(tealetarray[k], NULL);
+        tealet_switch(tealetarray[k], NULL, TEALET_SWITCH_DEFAULT);
         return 1;
       }
     }
@@ -1033,7 +1033,7 @@ void test_random2(void) {
     for (i = 1; i < ARRAYSIZE; i++)
       if (tealetarray[i]) {
         status++;
-        tealet_switch(tealetarray[i], NULL);
+        tealet_switch(tealetarray[i], NULL, TEALET_SWITCH_DEFAULT);
         break;
       }
     if (i == ARRAYSIZE)
@@ -1118,7 +1118,7 @@ tealet_t *mem_error_tealet(tealet_t *t1, void *arg) {
   int res;
   tealet_t *peer = (tealet_t *)arg;
   talloc_fail = 1;
-  res = tealet_switch(peer, &myarg);
+  res = tealet_switch(peer, &myarg, TEALET_SWITCH_DEFAULT);
   assert(res == TEALET_ERR_MEM);
   tealet_exit(peer, myarg, TEALET_EXIT_DELETE);
   assert(0); // never runs
@@ -1167,7 +1167,7 @@ void test_exit_defunct_target_returns_error(void) {
   assert(tealet_create(g_main, &exiter, test_exit_defunct_fail_run, NULL) == 0);
   assert(exiter != NULL);
   arg = (void *)victim;
-  result = tealet_switch(exiter, &arg);
+  result = tealet_switch(exiter, &arg, TEALET_SWITCH_DEFAULT);
   assert(result == 0);
 
   tealet_delete(victim);
@@ -1194,7 +1194,7 @@ void test_exit_explicit_panic(void) {
   assert(tealet_create(g_main, &exiter, test_explicit_panic_exit_run, NULL) == 0);
   assert(exiter != NULL);
   arg = (void *)g_main;
-  result = tealet_switch(exiter, &arg);
+  result = tealet_switch(exiter, &arg, TEALET_SWITCH_DEFAULT);
   assert(result == TEALET_ERR_PANIC);
 
   fini_test();
@@ -1220,7 +1220,7 @@ void test_debug_swap_far_invalid_caller_check_main(void) {
   result = tealet_debug_swap_far(g_main, new_far, &old_far);
   assert(result == 0);
 
-  result = tealet_switch(child, NULL);
+  result = tealet_switch(child, NULL, TEALET_SWITCH_DEFAULT);
   assert(result == TEALET_ERR_INVAL);
 
   result = tealet_debug_swap_far(g_main, old_far, &old_far);
@@ -1245,7 +1245,7 @@ static tealet_t *test_invalid_caller_check_child_run(tealet_t *current, void *ar
   result = tealet_debug_swap_far(current, new_far, &old_far);
   assert(result == 0);
 
-  result = tealet_switch(g_main, NULL);
+  result = tealet_switch(g_main, NULL, TEALET_SWITCH_DEFAULT);
   assert(result == TEALET_ERR_INVAL);
 
   result = tealet_debug_swap_far(current, old_far, &old_far);

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -1115,16 +1115,20 @@ void test_mem_error(void) {
 }
 
 #if TEALET_WITH_TESTING
-static tealet_t *test_panic_exit_run(tealet_t *current, void *arg) {
+static tealet_t *test_exit_defunct_fail_run(tealet_t *current, void *arg) {
   tealet_t *target = (tealet_t *)arg;
+  int result;
 
   assert(current != g_main);
-  tealet_exit(target, NULL, TEALET_EXIT_DELETE);
+  result = tealet_exit(target, NULL, TEALET_EXIT_DELETE);
+  assert(result == TEALET_ERR_DEFUNCT);
+
+  tealet_exit(current->main, NULL, TEALET_EXIT_DELETE);
   assert(0);
   return NULL;
 }
 
-void test_exit_reroute_panic(void) {
+void test_exit_defunct_target_returns_error(void) {
   tealet_t *victim;
   tealet_t *exiter;
   int result;
@@ -1137,13 +1141,38 @@ void test_exit_reroute_panic(void) {
   result = tealet_debug_force_defunct(victim);
   assert(result == 0);
 
-  exiter = tealet_create(g_main, test_panic_exit_run, NULL);
+  exiter = tealet_create(g_main, test_exit_defunct_fail_run, NULL);
   assert(exiter != NULL);
   arg = (void *)victim;
   result = tealet_switch(exiter, &arg);
-  assert(result == TEALET_ERR_PANIC);
+  assert(result == 0);
 
   tealet_delete(victim);
+  fini_test();
+}
+
+static tealet_t *test_explicit_panic_exit_run(tealet_t *current, void *arg) {
+  tealet_t *target = (tealet_t *)arg;
+
+  assert(current != g_main);
+  tealet_exit(target, NULL, TEALET_EXIT_DELETE | TEALET_EXIT_PANIC);
+  assert(0);
+  return NULL;
+}
+
+void test_exit_explicit_panic(void) {
+  tealet_t *exiter;
+  int result;
+  void *arg;
+
+  init_test();
+
+  exiter = tealet_create(g_main, test_explicit_panic_exit_run, NULL);
+  assert(exiter != NULL);
+  arg = (void *)g_main;
+  result = tealet_switch(exiter, &arg);
+  assert(result == TEALET_ERR_PANIC);
+
   fini_test();
 }
 
@@ -1247,7 +1276,8 @@ static test_entry_t test_list[] = {
     {"test_stats", test_stats},
     {"test_mem_error", test_mem_error},
 #if TEALET_WITH_TESTING
-    {"test_exit_reroute_panic", test_exit_reroute_panic},
+  {"test_exit_defunct_target_returns_error", test_exit_defunct_target_returns_error},
+  {"test_exit_explicit_panic", test_exit_explicit_panic},
     {"test_debug_swap_far_invalid_caller_check_main", test_debug_swap_far_invalid_caller_check_main},
     {"test_debug_swap_far_invalid_caller_check_child", test_debug_swap_far_invalid_caller_check_child},
 #endif

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -1198,6 +1198,36 @@ void test_oom_force_marks_source_defunct(void) {
   fini_test();
 }
 
+static tealet_t *oom_main_probe_run(tealet_t *current, void *arg) {
+  (void)arg;
+  return current->main;
+}
+
+void test_oom_force_main_not_defunct(void) {
+  tealet_t *worker;
+  int result;
+
+  /* Purpose: when FORCE is requested from main and save fails under OOM,
+   * main must not be marked defunct; the operation returns TEALET_ERR_MEM.
+   */
+  init_test_extra(NULL, 0);
+
+  worker = NULL;
+  assert(tealet_create(g_main, &worker, oom_main_probe_run, NULL) == 0);
+  assert(worker != NULL);
+
+  talloc_fail = 1;
+  result = tealet_switch(worker, NULL, TEALET_SWITCH_FORCE);
+  assert(result == TEALET_ERR_MEM);
+
+  talloc_fail = 0;
+  assert(tealet_status(g_main) == TEALET_STATUS_ACTIVE);
+  assert(tealet_status(worker) != TEALET_STATUS_DEFUNCT);
+
+  tealet_delete(worker);
+  fini_test();
+}
+
 static tealet_t *oom_w2 = NULL;
 
 static tealet_t *oom_force_peer_to_main_panic_run(tealet_t *current, void *arg) {
@@ -1451,6 +1481,7 @@ static test_entry_t test_list[] = {
     {"test_stats", test_stats},
     {"test_mem_error", test_mem_error},
     {"test_oom_force_marks_source_defunct", test_oom_force_marks_source_defunct},
+    {"test_oom_force_main_not_defunct", test_oom_force_main_not_defunct},
     {"test_oom_force_peer_then_panic_main", test_oom_force_peer_then_panic_main},
     {"test_exit_self_invalid", test_exit_self_invalid},
 #if TEALET_WITH_TESTING

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -222,20 +222,35 @@ void fini_test() {
 static tealet_t *tealet_new_x(tealet_t *m, tealet_run_t run, void **parg) {
   static int counter = 0;
   int i;
+  int rc;
   tealet_t *r;
 
   counter += 1;
-  if (counter % 2)
-    return tealet_new(m, run, parg, NULL);
-
-  r = tealet_create(m, run, NULL);
-  if (!r)
+  if (counter % 2) {
+    r = NULL;
+    rc = tealet_new(m, &r, run, parg, NULL);
+    if (rc != 0)
+      return NULL;
     return r;
+  }
+
+  r = NULL;
+  rc = tealet_create(m, &r, run, NULL);
+  if (rc != 0)
+    return NULL;
   i = tealet_switch(r, parg);
   if (i != 0) {
     tealet_delete(r);
     return 0;
   }
+  return r;
+}
+
+static tealet_t *tealet_new_native_call(tealet_t *m, tealet_run_t run, void **parg, void *stack_far) {
+  tealet_t *r = NULL;
+  int rc = tealet_new(m, &r, run, parg, stack_far);
+  if (rc != 0)
+    return NULL;
   return r;
 }
 
@@ -335,7 +350,7 @@ static tealet_t *stub_new3(tealet_t *t, tealet_run_t run, void **parg, void *sta
 
 typedef tealet_t *(*t_new)(tealet_t *, tealet_run_t, void **, void *);
 static t_new newarray[] = {tealet_new_rnd, stub_new, stub_new2, stub_new3};
-static tealet_t *(*tealet_new_native)(tealet_t *, tealet_run_t, void **, void *) = tealet_new;
+static tealet_t *(*tealet_new_native)(tealet_t *, tealet_run_t, void **, void *) = tealet_new_native_call;
 
 static t_new get_new() {
   if (newmode >= 0)
@@ -613,7 +628,8 @@ void test_lock_transitions_fork(void) {
 void test_simple_create(void) {
   tealet_t *t;
   init_test();
-  t = tealet_create(g_main, test_simple_run, NULL);
+  t = NULL;
+  assert(tealet_create(g_main, &t, test_simple_run, NULL) == 0);
   assert(status == 0);
   tealet_delete(t);
   fini_test();
@@ -622,7 +638,8 @@ void test_simple_create(void) {
 void test_simple_create_and_run(void) {
   tealet_t *t;
   init_test();
-  t = tealet_create(g_main, test_simple_run, NULL);
+  t = NULL;
+  assert(tealet_create(g_main, &t, test_simple_run, NULL) == 0);
   tealet_switch(t, NULL);
   assert(status == 1);
   assert(tealet_previous(g_main) == NULL);
@@ -642,7 +659,8 @@ void test_create_previous(void) {
   tealet_t *t;
   init_test();
   /* Create tealet without running it */
-  t = tealet_create(g_main, test_create_previous_run, NULL);
+  t = NULL;
+  assert(tealet_create(g_main, &t, test_create_previous_run, NULL) == 0);
   assert(status == 0);
   /* Now switch to it - it should see main as previous */
   tealet_switch(t, NULL);
@@ -661,7 +679,8 @@ void test_previous_cleared_on_manual_delete(void) {
   tealet_t *t;
 
   init_test();
-  t = tealet_create(g_main, test_previous_manual_delete_run, NULL);
+  t = NULL;
+  assert(tealet_create(g_main, &t, test_previous_manual_delete_run, NULL) == 0);
   assert(t != NULL);
 
   tealet_switch(t, NULL);
@@ -1144,7 +1163,8 @@ void test_exit_defunct_target_returns_error(void) {
   result = tealet_debug_force_defunct(victim);
   assert(result == 0);
 
-  exiter = tealet_create(g_main, test_exit_defunct_fail_run, NULL);
+  exiter = NULL;
+  assert(tealet_create(g_main, &exiter, test_exit_defunct_fail_run, NULL) == 0);
   assert(exiter != NULL);
   arg = (void *)victim;
   result = tealet_switch(exiter, &arg);
@@ -1170,7 +1190,8 @@ void test_exit_explicit_panic(void) {
 
   init_test();
 
-  exiter = tealet_create(g_main, test_explicit_panic_exit_run, NULL);
+  exiter = NULL;
+  assert(tealet_create(g_main, &exiter, test_explicit_panic_exit_run, NULL) == 0);
   assert(exiter != NULL);
   arg = (void *)g_main;
   result = tealet_switch(exiter, &arg);

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -219,7 +219,7 @@ void fini_test() {
 /**************************************/
 
 // create a tealet, either with tealet_create or tealet_new
-static tealet_t *tealet_new_x(tealet_t *m, tealet_run_t run, void **parg) {
+static int tealet_new_x(tealet_t *m, tealet_t **out, tealet_run_t run, void **parg, void *stack_far) {
   static int counter = 0;
   int i;
   int rc;
@@ -228,22 +228,24 @@ static tealet_t *tealet_new_x(tealet_t *m, tealet_run_t run, void **parg) {
   counter += 1;
   if (counter % 2) {
     r = NULL;
-    rc = tealet_new(m, &r, run, parg, NULL);
+    rc = tealet_new(m, &r, run, parg, stack_far);
     if (rc != 0)
-      return NULL;
-    return r;
+      return rc;
+    *out = r;
+    return 0;
   }
 
   r = NULL;
-  rc = tealet_create(m, &r, run, NULL);
+  rc = tealet_create(m, &r, run, stack_far);
   if (rc != 0)
-    return NULL;
+    return rc;
   i = tealet_switch(r, parg, TEALET_SWITCH_DEFAULT);
   if (i != 0) {
     tealet_delete(r);
-    return 0;
+    return i;
   }
-  return r;
+  *out = r;
+  return 0;
 }
 
 static tealet_t *tealet_new_native_call(tealet_t *m, tealet_run_t run, void **parg, void *stack_far) {
@@ -255,35 +257,32 @@ static tealet_t *tealet_new_native_call(tealet_t *m, tealet_run_t run, void **pa
 }
 
 /* create a tealet or stub low on the stack */
-static tealet_t *tealet_new_descend(tealet_t *t, int level, tealet_run_t run, void **parg) {
-  tealet_t *stub;
+static int tealet_new_descend(tealet_t *t, tealet_t **out, int level, tealet_run_t run, void **parg, void *stack_far) {
   int boo[10];
   boo[9] = 0;
   (void)boo;
   if (level > 0)
-    return tealet_new_descend(t, level - 1, run, parg);
+    return tealet_new_descend(t, out, level - 1, run, parg, stack_far);
   if (run)
-    return tealet_new_x(t, run, parg);
-  if (tealet_stub_new(t, &stub, NULL) != 0)
-    return NULL;
-  return stub;
+    return tealet_new_x(t, out, run, parg, stack_far);
+  return tealet_stub_new(t, out, stack_far);
 }
 
 /***************************************
  * methods for creating tealets in different ways
  */
 
-static tealet_t *tealet_new_rnd(tealet_t *t, tealet_run_t run, void **parg, void *stack_far) {
-  (void)stack_far;
-  return tealet_new_descend(t, rand() % 20, run, parg);
+static int tealet_new_rnd(tealet_t *t, tealet_t **out, tealet_run_t run, void **parg, void *stack_far) {
+  return tealet_new_descend(t, out, rand() % 20, run, parg, stack_far);
 }
 
-static tealet_t *stub_new(tealet_t *t, tealet_run_t run, void **parg, void *stack_far) {
-  tealet_t *stub = tealet_new_descend(t, rand() % 20, NULL, NULL);
+static int stub_new(tealet_t *t, tealet_t **out, tealet_run_t run, void **parg, void *stack_far) {
+  tealet_t *stub = NULL;
+  int rc;
   int res;
-  (void)stack_far;
-  if (stub == NULL)
-    return NULL;
+  rc = tealet_new_descend(t, &stub, rand() % 20, NULL, NULL, stack_far);
+  if (rc != 0)
+    return rc;
   if (run)
     res = tealet_stub_run(stub, run, parg);
   else
@@ -291,22 +290,24 @@ static tealet_t *stub_new(tealet_t *t, tealet_run_t run, void **parg, void *stac
   if (res) {
     tealet_delete(stub);
     assert(res == TEALET_ERR_MEM);
-    return NULL;
+    return res;
   }
-  return stub;
+  *out = stub;
+  return 0;
 }
 
-static tealet_t *stub_new2(tealet_t *t, tealet_run_t run, void **parg, void *stack_far) {
+static int stub_new2(tealet_t *t, tealet_t **out, tealet_run_t run, void **parg, void *stack_far) {
   tealet_t *dup, *stub;
+  int rc;
   int res;
-  (void)stack_far;
-  stub = tealet_new_descend(t, rand() % 20, NULL, NULL);
-  if (stub == NULL)
-    return NULL;
+  stub = NULL;
+  rc = tealet_new_descend(t, &stub, rand() % 20, NULL, NULL, stack_far);
+  if (rc != 0)
+    return rc;
   dup = tealet_duplicate(stub);
   if (dup == NULL) {
     tealet_delete(stub);
-    return NULL;
+    return TEALET_ERR_MEM;
   }
   if (run)
     res = tealet_stub_run(dup, run, parg);
@@ -316,39 +317,44 @@ static tealet_t *stub_new2(tealet_t *t, tealet_run_t run, void **parg, void *sta
   if (res) {
     tealet_delete(dup);
     assert(res == TEALET_ERR_MEM);
-    return NULL;
+    return res;
   }
-  return dup;
+  *out = dup;
+  return 0;
 }
 
-static tealet_t *stub_new3(tealet_t *t, tealet_run_t run, void **parg, void *stack_far) {
+static int stub_new3(tealet_t *t, tealet_t **out, tealet_run_t run, void **parg, void *stack_far) {
   tealet_t *dup;
+  int rc;
   int res;
-  (void)stack_far;
   if ((rand() % 10) == 0)
     if (the_stub != NULL) {
       tealet_delete(the_stub);
       the_stub = NULL;
     }
+  if (the_stub == NULL) {
+    rc = tealet_new_descend(t, &the_stub, rand() % 20, NULL, NULL, stack_far);
+    if (rc != 0)
+      return rc;
+  }
   if (the_stub == NULL)
-    the_stub = tealet_new_descend(t, rand() % 20, NULL, NULL);
-  if (the_stub == NULL)
-    return NULL;
+    return TEALET_ERR_MEM;
   dup = tealet_duplicate(the_stub);
   if (dup == NULL)
-    return NULL;
+    return TEALET_ERR_MEM;
   if (run) {
     res = tealet_stub_run(dup, run, parg);
     if (res) {
       tealet_delete(dup);
       assert(res == TEALET_ERR_MEM);
-      return NULL;
+      return res;
     }
   }
-  return dup;
+  *out = dup;
+  return 0;
 }
 
-typedef tealet_t *(*t_new)(tealet_t *, tealet_run_t, void **, void *);
+typedef int (*t_new)(tealet_t *, tealet_t **, tealet_run_t, void **, void *);
 static t_new newarray[] = {tealet_new_rnd, stub_new, stub_new2, stub_new3};
 static tealet_t *(*tealet_new_native)(tealet_t *, tealet_run_t, void **, void *) = tealet_new_native_call;
 
@@ -357,7 +363,8 @@ static t_new get_new() {
     return newarray[newmode];
   return newarray[rand() % (sizeof(newarray) / sizeof(*newarray))];
 }
-#define tealet_new get_new()
+/* Explicitly named test-only creator dispatch to avoid shadowing public APIs. */
+#define TEALET_TEST_NEW(T, O, R, A, S) (get_new()((T), (O), (R), (A), (S)))
 
 /************************************************************/
 
@@ -702,12 +709,16 @@ tealet_t *test_status_run(tealet_t *t1, void *arg) {
 
 void test_status(void) {
   tealet_t *stub1;
+  int result;
   init_test();
 
   assert(tealet_status(g_main) == TEALET_STATUS_ACTIVE);
   assert(TEALET_IS_MAIN(g_main));
 
-  stub1 = tealet_new(g_main, NULL, NULL, NULL);
+  stub1 = NULL;
+  result = TEALET_TEST_NEW(g_main, &stub1, NULL, NULL, NULL);
+  assert(result == 0);
+  assert(stub1 != NULL);
   assert(tealet_status(stub1) == TEALET_STATUS_ACTIVE);
   assert(!TEALET_IS_MAIN(stub1));
   tealet_stub_run(stub1, test_status_run, NULL);
@@ -731,7 +742,10 @@ void test_exit(void) {
   int result;
   void *arg;
   init_test();
-  stub1 = tealet_new(g_main, NULL, NULL, NULL);
+  stub1 = NULL;
+  result = TEALET_TEST_NEW(g_main, &stub1, NULL, NULL, NULL);
+  assert(result == 0);
+  assert(stub1 != NULL);
   stub2 = tealet_duplicate(stub1);
   arg = (void *)TEALET_EXIT_DEFAULT;
   result = tealet_stub_run(stub1, test_exit_run, &arg);
@@ -825,10 +839,14 @@ void test_switch_self_panic(void) {
 tealet_t *test_switch_new_1(tealet_t *t1, void *arg) {
   tealet_t *caller = (tealet_t *)arg;
   tealet_t *stub;
+  int result;
   /* switch back to the creator */
   tealet_switch(caller, NULL, TEALET_SWITCH_DEFAULT);
   /* now we want to trample the stack */
-  stub = tealet_new_descend(t1, 50, NULL, NULL);
+  stub = NULL;
+  result = tealet_new_descend(t1, &stub, 50, NULL, NULL, NULL);
+  assert(result == 0);
+  assert(stub != NULL);
   tealet_delete(stub);
   /* and back to main */
   return g_main;
@@ -847,12 +865,16 @@ tealet_t *test_switch_new_2(tealet_t *t2, void *arg) {
 void test_switch_new(void) {
   tealet_t *tealet1, *tealet2;
   void *arg;
+  int result;
   init_test();
   arg = (void *)tealet_current(g_main);
   tealet1 = tealet_new_native_call(g_main, test_switch_new_1, &arg, NULL);
   /* the tealet is now running */
   arg = (void *)tealet1;
-  tealet2 = tealet_new_descend(g_main, 4, test_switch_new_2, &arg);
+  tealet2 = NULL;
+  result = tealet_new_descend(g_main, &tealet2, 4, test_switch_new_2, &arg, NULL);
+  assert(result == 0);
+  assert(tealet2 != NULL);
   assert(tealet_status(tealet2) == TEALET_STATUS_ACTIVE);
   tealet_switch(tealet2, NULL, TEALET_SWITCH_DEFAULT);
   /* tealet should be dead now */
@@ -1083,10 +1105,14 @@ tealet_t *extra_tealet(tealet_t *cur, void *arg) {
 void test_extra(void) {
   tealet_t *t1, *t2;
   extradata ed = {1, "abcd", 2};
+  int result;
   init_test_extra(NULL, sizeof(extradata));
   *TEALET_EXTRA(g_main, extradata) = ed;
 
-  t1 = tealet_new(g_main, NULL, NULL, NULL);
+  t1 = NULL;
+  result = TEALET_TEST_NEW(g_main, &t1, NULL, NULL, NULL);
+  assert(result == 0);
+  assert(t1 != NULL);
   *TEALET_EXTRA(t1, extradata) = ed;
   t2 = tealet_duplicate(t1);
   tealet_stub_run(t1, extra_tealet, NULL);
@@ -1109,6 +1135,7 @@ void test_stats(void) {
   tealet_t *t1;
   tealet_stats_t stats;
   int a, b;
+  int result;
   init_test_extra(NULL, 0);
 
   /* Skip this test if stats are not enabled */
@@ -1120,7 +1147,10 @@ void test_stats(void) {
   tealet_get_stats(g_main, &stats);
   assert(stats.n_active == 1);
   assert(stats.n_total == 1);
-  t1 = tealet_new(g_main, NULL, NULL, NULL);
+  t1 = NULL;
+  result = TEALET_TEST_NEW(g_main, &t1, NULL, NULL, NULL);
+  assert(result == 0);
+  assert(t1 != NULL);
   tealet_get_stats(g_main, &stats);
   /* can be more than 2 because of stub tealet */
   a = stats.n_active;
@@ -1338,7 +1368,9 @@ void test_exit_defunct_target_returns_error(void) {
 
   init_test();
 
-  victim = tealet_new(g_main, NULL, NULL, NULL);
+  victim = NULL;
+  result = TEALET_TEST_NEW(g_main, &victim, NULL, NULL, NULL);
+  assert(result == 0);
   assert(victim != NULL);
   result = tealet_debug_force_defunct(victim);
   assert(result == 0);
@@ -1393,7 +1425,9 @@ void test_debug_swap_far_invalid_caller_check_main(void) {
    */
   init_test();
 
-  child = tealet_new(g_main, NULL, NULL, NULL);
+  child = NULL;
+  result = TEALET_TEST_NEW(g_main, &child, NULL, NULL, NULL);
+  assert(result == 0);
   assert(child != NULL);
 
   new_far = (void *)((uintptr_t)&stack_probe + ((uintptr_t)64 << 20));

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -1300,8 +1300,8 @@ static test_entry_t test_list[] = {
     {"test_stats", test_stats},
     {"test_mem_error", test_mem_error},
 #if TEALET_WITH_TESTING
-  {"test_exit_defunct_target_returns_error", test_exit_defunct_target_returns_error},
-  {"test_exit_explicit_panic", test_exit_explicit_panic},
+    {"test_exit_defunct_target_returns_error", test_exit_defunct_target_returns_error},
+    {"test_exit_explicit_panic", test_exit_explicit_panic},
     {"test_debug_swap_far_invalid_caller_check_main", test_debug_swap_far_invalid_caller_check_main},
     {"test_debug_swap_far_invalid_caller_check_child", test_debug_swap_far_invalid_caller_check_child},
 #endif

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -797,6 +797,24 @@ void test_switch(void) {
   fini_test();
 }
 
+void test_switch_self_panic(void) {
+  tealet_t *runner;
+  int result;
+
+  init_test();
+
+  /* Self-switch with PANIC should consume panic immediately. */
+  result = tealet_switch(g_main, NULL, TEALET_SWITCH_PANIC);
+  assert(result == TEALET_ERR_PANIC);
+
+  /* Ensure panic flag is not left armed for a later unrelated switch. */
+  runner = tealet_new_native_call(g_main, test_simple_run, NULL, NULL);
+  assert(runner != NULL);
+  assert(status == 1);
+
+  fini_test();
+}
+
 /************************************************************/
 
 /* 1 is high on the stack.  We then create 2 lower on the stack */
@@ -1136,6 +1154,31 @@ void test_mem_error(void) {
   fini_test();
 }
 
+static tealet_t *test_exit_self_invalid_run(tealet_t *current, void *arg) {
+  int result;
+  (void)arg;
+
+  result = tealet_exit((tealet_t *)current, NULL, TEALET_EXIT_DELETE);
+  assert(result == TEALET_ERR_INVAL);
+
+  tealet_exit(current->main, NULL, TEALET_EXIT_DELETE);
+  assert(0);
+  return NULL;
+}
+
+void test_exit_self_invalid(void) {
+  tealet_t *runner;
+
+  init_test();
+
+  runner = NULL;
+  assert(tealet_create(g_main, &runner, test_exit_self_invalid_run, NULL) == 0);
+  assert(runner != NULL);
+  assert(tealet_switch(runner, NULL, TEALET_SWITCH_DEFAULT) == 0);
+
+  fini_test();
+}
+
 #if TEALET_WITH_TESTING
 static tealet_t *test_exit_defunct_fail_run(tealet_t *current, void *arg) {
   tealet_t *target = (tealet_t *)arg;
@@ -1291,6 +1334,7 @@ static test_entry_t test_list[] = {
     {"test_status", test_status},
     {"test_exit", test_exit},
     {"test_switch", test_switch},
+    {"test_switch_self_panic", test_switch_self_panic},
     {"test_switch_new", test_switch_new},
     {"test_arg", test_arg},
     {"test_random", test_random},
@@ -1299,6 +1343,7 @@ static test_entry_t test_list[] = {
     {"test_memstats", test_memstats},
     {"test_stats", test_stats},
     {"test_mem_error", test_mem_error},
+    {"test_exit_self_invalid", test_exit_self_invalid},
 #if TEALET_WITH_TESTING
     {"test_exit_defunct_target_returns_error", test_exit_defunct_target_returns_error},
     {"test_exit_explicit_panic", test_exit_explicit_panic},

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -486,7 +486,7 @@ tealet_t *test_simple_run(tealet_t *t1, void *arg) {
 void test_simple(void) {
   tealet_t *t;
   init_test();
-  t = tealet_new(g_main, test_simple_run, NULL, NULL);
+  t = tealet_new_native_call(g_main, test_simple_run, NULL, NULL);
   assert(t != NULL);
   assert(status == 1);
   fini_test();
@@ -779,7 +779,7 @@ tealet_t *test_switch_1(tealet_t *t1, void *arg) {
   assert(status == 0);
   status = 1;
   assert(tealet_current(g_main) == t1);
-  tealet_new(g_main, test_switch_2, NULL, NULL);
+  assert(tealet_new_native_call(g_main, test_switch_2, NULL, NULL) != NULL);
   assert(status == 2);
   status = 3;
   assert(tealet_current(g_main) == t1);
@@ -792,7 +792,7 @@ tealet_t *test_switch_1(tealet_t *t1, void *arg) {
 
 void test_switch(void) {
   init_test();
-  tealet_new(g_main, test_switch_1, NULL, NULL);
+  assert(tealet_new_native_call(g_main, test_switch_1, NULL, NULL) != NULL);
   assert(status == 7);
   fini_test();
 }
@@ -828,7 +828,7 @@ void test_switch_new(void) {
   void *arg;
   init_test();
   arg = (void *)tealet_current(g_main);
-  tealet1 = tealet_new(g_main, test_switch_new_1, &arg, NULL);
+  tealet1 = tealet_new_native_call(g_main, test_switch_new_1, &arg, NULL);
   /* the tealet is now running */
   arg = (void *)tealet1;
   tealet2 = tealet_new_descend(g_main, 4, test_switch_new_2, &arg);
@@ -857,7 +857,7 @@ void test_arg(void) {
   tealet_t *t1;
   init_test();
   myarg = (void *)g_main;
-  t1 = tealet_new(g_main, test_arg_1, &myarg, NULL);
+  t1 = tealet_new_native_call(g_main, test_arg_1, &myarg, NULL);
   assert(myarg == (void *)1);
   myarg = (void *)2;
   tealet_switch(t1, &myarg, TEALET_SWITCH_DEFAULT);
@@ -896,7 +896,7 @@ static void random_run(int index) {
       if (status >= MAX_STATUS)
         break;
       arg = (void *)(intptr_t)i;
-      tealet_new(g_main, random_new_tealet, &arg, NULL);
+      assert(tealet_new_native_call(g_main, random_new_tealet, &arg, NULL) != NULL);
     } else {
       tealet_switch(tealetarray[i], NULL, TEALET_SWITCH_DEFAULT);
     }
@@ -968,7 +968,7 @@ tealet_t *random2_tealet(tealet_t *cur, void *arg) {
 }
 void random2_new(int index) {
   void *arg = (void *)(intptr_t)index;
-  tealet_new(g_main, random2_tealet, &arg, NULL);
+  assert(tealet_new_native_call(g_main, random2_tealet, &arg, NULL) != NULL);
 }
 
 int random2_descend(int index, int level) {
@@ -1130,7 +1130,7 @@ void test_mem_error(void) {
   tealet_t *t1;
   init_test_extra(NULL, 0);
   myarg = (void *)g_main;
-  t1 = tealet_new(g_main, mem_error_tealet, &myarg, NULL);
+  t1 = tealet_new_native_call(g_main, mem_error_tealet, &myarg, NULL);
   assert(t1);
   talloc_fail = 0;
   fini_test();
@@ -1264,7 +1264,7 @@ void test_debug_swap_far_invalid_caller_check_child(void) {
    */
   init_test();
 
-  runner = tealet_new(g_main, test_invalid_caller_check_child_run, NULL, NULL);
+  runner = tealet_new_native_call(g_main, test_invalid_caller_check_child_run, NULL, NULL);
   assert(runner != NULL);
 
   fini_test();

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -801,6 +801,9 @@ void test_switch_self_panic(void) {
   tealet_t *runner;
   int result;
 
+  /* Purpose: self-switch with PANIC should return TEALET_ERR_PANIC
+   * immediately and must not leak panic state into later switches.
+   */
   init_test();
 
   /* Self-switch with PANIC should consume panic immediately. */
@@ -1154,6 +1157,107 @@ void test_mem_error(void) {
   fini_test();
 }
 
+static tealet_t *oom_force_to_main_run(tealet_t *current, void *arg) {
+  int result;
+  (void)arg;
+
+  /* First attempt without FORCE fails in-place with MEM. */
+  talloc_fail = 1;
+  result = tealet_switch(current->main, NULL, TEALET_SWITCH_DEFAULT);
+  assert(result == TEALET_ERR_MEM);
+
+  /* FORCE should continue by defuncting current and transferring out. */
+  result = tealet_switch(current->main, NULL, TEALET_SWITCH_FORCE);
+  assert(0);
+  assert(result == 0);
+  return NULL;
+}
+
+void test_oom_force_marks_source_defunct(void) {
+  tealet_t *worker;
+  int result;
+
+  /* Purpose: under OOM, FORCE switch-to-main should succeed by marking the
+   * source worker defunct. The defunct worker must reject future switches.
+   */
+  init_test_extra(NULL, 0);
+
+  worker = NULL;
+  assert(tealet_create(g_main, &worker, oom_force_to_main_run, NULL) == 0);
+  assert(worker != NULL);
+
+  result = tealet_switch(worker, NULL, TEALET_SWITCH_DEFAULT);
+  assert(result == 0);
+
+  talloc_fail = 0;
+  assert(tealet_status(worker) == TEALET_STATUS_DEFUNCT);
+  result = tealet_switch(worker, NULL, TEALET_SWITCH_DEFAULT);
+  assert(result == TEALET_ERR_DEFUNCT);
+
+  tealet_delete(worker);
+  fini_test();
+}
+
+static tealet_t *oom_w2 = NULL;
+
+static tealet_t *oom_force_peer_to_main_panic_run(tealet_t *current, void *arg) {
+  int result;
+  (void)arg;
+
+  /* Clear allocator fault so this switch-out can complete. */
+  talloc_fail = 0;
+  result = tealet_switch(current->main, NULL, TEALET_SWITCH_PANIC);
+  assert(0);
+  assert(result == TEALET_ERR_PANIC);
+  return NULL;
+}
+
+static tealet_t *oom_force_to_peer_run(tealet_t *current, void *arg) {
+  int result;
+  (void)arg;
+
+  assert(oom_w2 != NULL);
+
+  talloc_fail = 1;
+  result = tealet_switch(oom_w2, NULL, TEALET_SWITCH_FORCE);
+  assert(0);
+  assert(result == 0);
+  (void)current;
+  return NULL;
+}
+
+void test_oom_force_peer_then_panic_main(void) {
+  tealet_t *w1;
+  int result;
+
+  /* Purpose: with two workers, OOM during w1->w2 with FORCE should defunct w1,
+   * continue to w2, and then panic-tagged switch to main should surface as
+   * TEALET_ERR_PANIC on main.
+   */
+  init_test_extra(NULL, 0);
+
+  oom_w2 = NULL;
+  assert(tealet_create(g_main, &oom_w2, oom_force_peer_to_main_panic_run, NULL) == 0);
+  assert(oom_w2 != NULL);
+
+  w1 = NULL;
+  assert(tealet_create(g_main, &w1, oom_force_to_peer_run, NULL) == 0);
+  assert(w1 != NULL);
+
+  result = tealet_switch(w1, NULL, TEALET_SWITCH_DEFAULT);
+  assert(result == TEALET_ERR_PANIC);
+
+  assert(tealet_status(w1) == TEALET_STATUS_DEFUNCT);
+  result = tealet_switch(w1, NULL, TEALET_SWITCH_DEFAULT);
+  assert(result == TEALET_ERR_DEFUNCT);
+
+  tealet_delete(w1);
+  tealet_delete(oom_w2);
+  oom_w2 = NULL;
+  talloc_fail = 0;
+  fini_test();
+}
+
 static tealet_t *test_exit_self_invalid_run(tealet_t *current, void *arg) {
   int result;
   (void)arg;
@@ -1169,6 +1273,9 @@ static tealet_t *test_exit_self_invalid_run(tealet_t *current, void *arg) {
 void test_exit_self_invalid(void) {
   tealet_t *runner;
 
+  /* Purpose: exiting to self is invalid and must report TEALET_ERR_INVAL
+   * (not TEALET_ERR_DEFUNCT).
+   */
   init_test();
 
   runner = NULL;
@@ -1343,6 +1450,8 @@ static test_entry_t test_list[] = {
     {"test_memstats", test_memstats},
     {"test_stats", test_stats},
     {"test_mem_error", test_mem_error},
+    {"test_oom_force_marks_source_defunct", test_oom_force_marks_source_defunct},
+    {"test_oom_force_peer_then_panic_main", test_oom_force_peer_then_panic_main},
     {"test_exit_self_invalid", test_exit_self_invalid},
 #if TEALET_WITH_TESTING
     {"test_exit_defunct_target_returns_error", test_exit_defunct_target_returns_error},


### PR DESCRIPTION
## Summary
- Make switch and exit transfer behavior explicit via flags.
- Add switch flags: TEALET_SWITCH_DEFAULT, TEALET_SWITCH_FORCE, TEALET_SWITCH_PANIC.
- Document FORCE behavior explicitly for switch/exit, including the main-stack memory edge case where TEALET_ERR_MEM can still occur.
- Change creation APIs to status-return style with out-parameters: tealet_new, tealet_create, tealet_stub_new.
- Harden implicit run-return exit policy with clear retry/fallback flow.
- Align docs and changelog with the new signatures and behavior.

## Validation
- make test