### PR TITLE
Change default run-return behavior to keep tealets alive

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -126,6 +126,14 @@ tealet_exit(target, arg, TEALET_EXIT_DEFER);    // Defer to return statement
 - `TEALET_ERR_DEFUNCT`: Target tealet is corrupt
 - Use `assert()` for debug builds
 
+### Example snippets policy (review-critical)
+- Example/tutorial code is primarily illustrative and may intentionally omit
+  exhaustive error handling and edge-case branches.
+- Do not require production-style hardening in principle-focused snippets unless
+  the example is explicitly presented as a robust error-handling pattern.
+- In reviews, prioritize correctness of the demonstrated concept and API usage
+  over full defensive handling of every failure mode.
+
 ## Important Warnings
 
 ### Stack Data Safety

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Run-return lifecycle now keeps tealets alive by default**
+  - Returning from a tealet run function now follows `TEALET_EXIT_DEFAULT`
+    semantics (tealet remains allocated) instead of implicit delete.
+  - Automatic deletion remains available via explicit
+    `tealet_exit(..., TEALET_EXIT_DELETE)`.
+  - Tests and examples were updated to perform explicit `tealet_delete()`
+    cleanup where ownership remains with the caller.
+  - API/docs now clarify that `TEALET_EXIT_DELETE` invalidates outstanding
+    pointers to the exiting tealet after transfer.
+
 - **Creation semantics now use explicit allocation + bind/start steps**
   - `tealet_new()` now allocates and returns a NEW/unbound tealet handle.
   - `tealet_run()` is the bind/start primitive, with:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ int main(void) {
     void *arg = NULL;
     tealet_t *coro = tealet_new(main);
     tealet_run(coro, worker, &arg, NULL, TEALET_RUN_SWITCH);
+    tealet_delete(coro);
     
     tealet_finalize(main);
     return 0;

--- a/docs/API.md
+++ b/docs/API.md
@@ -486,7 +486,7 @@ tealet_t *my_run(tealet_t *current, void *arg) {
 ```c
 tealet_t *my_run(tealet_t *current, void *arg) {
     if (should_exit) {
-        /* store exit target and flags /*
+        /* store exit target and flags */
         tealet_exit(current->main, &result, TEALET_EXIT_DEFER);
         /* Returns here, can do cleanup */
         cleanup_resources();
@@ -494,9 +494,9 @@ tealet_t *my_run(tealet_t *current, void *arg) {
     
     /* return value ignored.
      * exit value from earlier will be used.
-    * Tealet is not auto-deleted unless TEALET_EXIT_DELETE is requested
+     * Tealet is not auto-deleted unless TEALET_EXIT_DELETE is requested
      */
-    return nullptr;
+    return NULL;
 }
 ```
 
@@ -523,10 +523,9 @@ Main is never marked defunct, so this edge case remains a hard memory failure.
 This means a successful forced exit can make other tealets become defunct as
 the trade-off for forward progress under memory pressure.
 
-**Note:** Returning from the run function automatically deletes the tealet using
-an implicit `tealet_exit()` policy: try requested target, panic+force to main
-if target is defunct, retry requested target with FORCE on memory failure, and
-if FORCE still fails (including the main-stack edge above), panic+force to main.
+**Note:** Returning from the run function does not auto-delete by default; it
+uses `TEALET_EXIT_DEFAULT` semantics unless `TEALET_EXIT_DELETE` was requested
+explicitly (for example via deferred exit flags).
 Use `tealet_exit()` when you need explicit control over deletion or want to
 exit from nested calls within the run function.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -200,7 +200,7 @@ tealet_t *my_run(tealet_t *current, void *arg) {
 }
 ```
 
-The run function executes until it returns or calls `tealet_exit()`. Upon return, the tealet is automatically deleted and execution transfers to the returned tealet.
+The run function executes until it returns or calls `tealet_exit()`. On return, execution transfers to the returned tealet and the current tealet remains allocated until explicitly deleted.
 
 ---
 
@@ -464,7 +464,7 @@ Exit current tealet and transfer control to target.
 
 **Flags:**
 - `TEALET_EXIT_DEFAULT` (0): Don't auto-delete, manual cleanup required
-- `TEALET_EXIT_DELETE`: Auto-delete tealet on exit (same as return behavior)
+- `TEALET_EXIT_DELETE`: Auto-delete tealet on exit; outstanding pointers to the exiting tealet become invalid after transfer
 - `TEALET_EXIT_DEFER`:  Store flags and argument, return to caller.  Will be used when
   tealet exits later.
 - `TEALET_EXIT_FORCE`: Force the requested transfer despite save-time memory pressure by defuncting affected non-main stacks as needed
@@ -494,7 +494,7 @@ tealet_t *my_run(tealet_t *current, void *arg) {
     
     /* return value ignored.
      * exit value from earlier will be used.
-     * Tealet is not auto-deleted
+    * Tealet is not auto-deleted unless TEALET_EXIT_DELETE is requested
      */
     return nullptr;
 }
@@ -1001,7 +1001,7 @@ tealet_delete(t);
 **Important:**
 - Cannot delete the currently executing tealet (use `tealet_exit()` instead)
 - Cannot delete the main tealet (use `tealet_finalize()`)
-- Tealets are automatically deleted when their run function returns
+- Tealets remain allocated when their run function returns
 - Only call on tealets you've kept alive explicitly
 
 **When to Use:**
@@ -1010,7 +1010,7 @@ tealet_delete(t);
 - Manual resource management
 
 **When Not Needed:**
-- Run function returns normally → automatic deletion
+- Run function returns normally → explicit `tealet_delete()` required
 - `tealet_exit()` with `TEALET_EXIT_DELETE` → automatic deletion
 
 ---
@@ -1342,7 +1342,7 @@ Switch result signaling explicit panic-tagged resume.
 ```c
 /* Exit flags (new names) */
 #define TEALET_EXIT_DEFAULT 0  /* Don't auto-delete */
-#define TEALET_EXIT_DELETE  1  /* Auto-delete on exit */
+#define TEALET_EXIT_DELETE  1  /* Auto-delete on exit; pointers to exiting tealet become invalid */
 #define TEALET_EXIT_DEFER   2  /* Defer exit to return */
 
 /* Switch flags */

--- a/docs/API.md
+++ b/docs/API.md
@@ -1414,8 +1414,11 @@ tealet_run(t, my_func, &arg, NULL, TEALET_RUN_SWITCH);
 **Return from run function:**
 - Normal completion
 - Simplest code path
-- Automatic cleanup (tealet is deleted)
+- Keeps tealet allocated by default; delete it later with `tealet_delete()`
 - Can only specify exit target tealet, no flags.
+
+**Note:** A prior deferred exit request with `TEALET_EXIT_DELETE` can still
+cause deletion when the run function eventually returns.
 
 **Use `tealet_exit()` with `TEALET_EXIT_DELETE`:**
 - Need to exit from nested function calls

--- a/docs/API.md
+++ b/docs/API.md
@@ -414,6 +414,9 @@ See the detailed policy discussion and conceptual retry flow under
 `tealet_exit()` / `TEALET_EXIT_NOFAIL` below; `TEALET_SWITCH_NOFAIL` follows
 the same shape with switch flags.
 
+When the requested target is `main`, `TEALET_SWITCH_NOFAIL` is guaranteed to
+succeed (transfer starts), because main is never allowed to become defunct.
+
 `TEALET_SWITCH_NOFAIL` can still return `TEALET_ERR_PANIC`, because panic is a
 legitimate switch-back signal (not a transfer failure to retry). In typical
 usage, panic-tagged fallbacks target main, so this check is usually needed on
@@ -539,6 +542,9 @@ run-function return handling:
     `TEALET_ERR_MEM` / `TEALET_ERR_DEFUNCT`
 - return other errors unchanged
 Main is never marked defunct, so this edge case remains a hard memory failure.
+
+When the requested target is `main`, `TEALET_EXIT_NOFAIL` is guaranteed to
+succeed (transfer starts), because main is never allowed to become defunct.
 
 This means a successful forced exit can make other tealets become defunct as
 the trade-off for forward progress under memory pressure.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1001,15 +1001,15 @@ tealet_delete(t);
 - Cannot delete the currently executing tealet (use `tealet_exit()` instead)
 - Cannot delete the main tealet (use `tealet_finalize()`)
 - Tealets remain allocated when their run function returns
-- Only call on tealets you've kept alive explicitly
+- Only call on tealets that are still allocated
 
 **When to Use:**
 - Deleting tealets that never ran (`TEALET_STATUS_INITIAL`)
 - Cleaning up tealets kept alive with `TEALET_EXIT_DEFAULT`
+- Cleaning up tealets that returned normally
 - Manual resource management
 
 **When Not Needed:**
-- Run function returns normally → explicit `tealet_delete()` required
 - `tealet_exit()` with `TEALET_EXIT_DELETE` → automatic deletion
 
 ---

--- a/docs/API.md
+++ b/docs/API.md
@@ -200,7 +200,7 @@ tealet_t *my_run(tealet_t *current, void *arg) {
 }
 ```
 
-The run function executes until it returns or calls `tealet_exit()`. On return, execution transfers to the returned tealet and the current tealet remains allocated until explicitly deleted.
+The run function executes until it returns or calls `tealet_exit()`. On return, execution transfers to the returned tealet and, by default, the current tealet remains allocated until explicitly deleted. However, a prior deferred `tealet_exit()` request with `TEALET_EXIT_DELETE` can still cause the tealet to be deleted when the run function returns.
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -174,43 +174,13 @@ tealet_t *my_run(tealet_t *current, void *arg) {
 - Required for main-lineage fork flows (see Advanced section)
 - Clearer intent in complex switching scenarios
 
-### ⚠️ Auto-Delete Danger
+### Cleanup on return
 
-When a run function returns (or calls `tealet_exit()` with `TEALET_EXIT_DELETE`), the tealet is **automatically deleted**. This can cause dangling pointer issues:
+When a run function returns, the tealet remains allocated. You must delete it explicitly when done.
 
 ```c
-/* ❌ DANGER: Race condition */
 tealet_t *worker_run(tealet_t *current, void *arg) {
     printf("Quick work\n");
-    return current->main;  /* Auto-deletes this tealet */
-}
-
-int main(void) {
-    tealet_alloc_t alloc = TEALET_ALLOC_INIT_MALLOC;
-    tealet_t *main = tealet_initialize(&alloc, 0);
-    
-    void *arg = NULL;
-    tealet_t *worker = NULL;
-    worker = tealet_new(main);
-    tealet_run(worker, worker_run, &arg, NULL, TEALET_RUN_SWITCH);
-    /* worker may already be deleted here! */
-    
-    int status = tealet_status(worker);  /* ❌ Dangling pointer! */
-    
-    tealet_finalize(main);
-    return 0;
-}
-```
-
-**What happened?** `tealet_run(..., TEALET_RUN_SWITCH)` starts the worker immediately. The worker completes and deletes itself before control returns. Now `worker` is a dangling pointer.
-
-### ✅ Safe Pattern: Prevent Auto-Delete
-
-```c
-tealet_t *worker_run(tealet_t *current, void *arg) {
-    printf("Work done\n");
-    /* Exit without auto-delete */
-    tealet_exit(current->main, NULL, TEALET_EXIT_DEFAULT);
     return current->main;
 }
 
@@ -222,13 +192,13 @@ int main(void) {
     tealet_t *worker = NULL;
     worker = tealet_new(main);
     tealet_run(worker, worker_run, &arg, NULL, TEALET_RUN_SWITCH);
-    /* worker still exists and can be queried */
+    /* worker is still valid here */
     
-    int status = tealet_status(worker);  /* ✅ Safe */
+    int status = tealet_status(worker);
     printf("Worker status: %d\n", status);
-    
-    /* Manual cleanup */
+
     tealet_delete(worker);
+    
     tealet_finalize(main);
     return 0;
 }
@@ -236,8 +206,8 @@ int main(void) {
 
 ### Exit Flags
 
-- `TEALET_EXIT_DEFAULT` (0): **Prevent auto-delete**; tealet must be manually deleted with `tealet_delete()`
-- `TEALET_EXIT_DELETE`: **Auto-delete on exit**; same as returning from the run function (the default behavior)
+- `TEALET_EXIT_DEFAULT` (0): **Keep tealet allocated**; tealet must be manually deleted with `tealet_delete()`
+- `TEALET_EXIT_DELETE`: **Auto-delete on exit**; any tealet pointers to the exiting tealet become invalid after transfer
 - `TEALET_EXIT_DEFER`: **Defer deletion to run function return** (advanced; see API docs)
 
 **Note:** The old `TEALET_FLAG_*` names are still available for backwards compatibility.
@@ -254,12 +224,13 @@ There is no supported way to decouple this order.
 
 ### When to Use Each
 
-**Auto-delete (default):**
+**Explicit auto-delete with `TEALET_EXIT_DELETE`:**
 ```c
 tealet_t *fire_and_forget(tealet_t *current, void *arg) {
     /* Do work that doesn't need caller intervention */
     printf("Task complete\n");
-    return current->main;  /* Auto-deletes */
+    tealet_exit(current->main, NULL, TEALET_EXIT_DELETE);
+    return current->main;  /* Fallback only */
 }
 ```
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -208,7 +208,7 @@ int main(void) {
 
 - `TEALET_EXIT_DEFAULT` (0): **Keep tealet allocated**; tealet must be manually deleted with `tealet_delete()`
 - `TEALET_EXIT_DELETE`: **Auto-delete on exit**; any tealet pointers to the exiting tealet become invalid after transfer
-- `TEALET_EXIT_DEFER`: **Defer deletion to run function return** (advanced; see API docs)
+- `TEALET_EXIT_DEFER`: **Defer exit transfer policy to run function return** (advanced; see API docs)
 
 **Note:** The old `TEALET_FLAG_*` names are still available for backwards compatibility.
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -162,9 +162,6 @@ tealet_t *my_run(tealet_t *current, void *arg) {
     
     /* ✅ Recommended: Explicit exit */
     tealet_exit(current->main, NULL, TEALET_EXIT_DELETE);
-    
-    /* Should not reach here */
-    return current->main;  /* Fallback only */
 }
 ```
 
@@ -232,7 +229,6 @@ tealet_t *fire_and_forget(tealet_t *current, void *arg) {
     /* Do work that doesn't need caller intervention */
     printf("Task complete\n");
     tealet_exit(current->main, NULL, TEALET_EXIT_DELETE);
-    return current->main;  /* Fallback only */
 }
 ```
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -176,7 +176,9 @@ tealet_t *my_run(tealet_t *current, void *arg) {
 
 ### Cleanup on return
 
-When a run function returns, the tealet remains allocated. You must delete it explicitly when done.
+When a run function returns normally, the tealet remains allocated. You must delete it explicitly when done.
+
+**Note:** This does not apply if the run function explicitly exits with `tealet_exit(..., TEALET_EXIT_DELETE)`. In particular, with `TEALET_RUN_SWITCH`, that exit path can free the tealet before `tealet_run()` returns, so the original handle is no longer safe to inspect, reuse, or delete.
 
 ```c
 tealet_t *worker_run(tealet_t *current, void *arg) {

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1432,7 +1432,7 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
      * Note: DEFER+FORCE is redundant in this implicit return path because a
      * TEALET_ERR_MEM retry always adds FORCE anyway.
      */
-    exit_flags = TEALET_EXIT_DELETE;
+    exit_flags = TEALET_EXIT_DEFAULT;
     exit_arg = NULL;
     if (g_main->g_flags & TEALET_EXIT_DEFER) {
       exit_flags = g_main->g_flags & (~TEALET_EXIT_DEFER);

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -242,10 +242,9 @@ tealet_t *tealet_new(tealet_t *tealet);
  * starts on a later tealet_switch() to that target.
  *
  * @warning With #TEALET_RUN_SWITCH, @p run may return/exit before
- * tealet_run() returns to the caller. If that path uses auto-delete
- * (implicit return policy or tealet_exit(..., #TEALET_EXIT_DELETE)),
- * the @p tealet handle can become invalid before tealet_run() returns.
- * Keep the tealet alive explicitly when post-call handle reuse is required.
+ * tealet_run() returns to the caller. If that path uses
+ * tealet_exit(..., #TEALET_EXIT_DELETE), the @p tealet handle can become
+ * invalid before tealet_run() returns.
  */
 TEALET_API
 int tealet_run(tealet_t *tealet, tealet_run_t run, void **parg, void *stack_far, int flags);
@@ -382,7 +381,7 @@ int tealet_switch(tealet_t *target, void **parg, int flags);
 
 /* Exit flags */
 #define TEALET_EXIT_DEFAULT 0 /* Don't auto-delete */
-#define TEALET_EXIT_DELETE 1  /* Auto-delete on exit */
+#define TEALET_EXIT_DELETE 1  /* Auto-delete on exit; pointers to exiting tealet become invalid */
 #define TEALET_EXIT_DEFER 2   /* Defer exit to return statement */
 #define TEALET_EXIT_FORCE 4   /* Force exit switch despite save-time memory failures */
 #define TEALET_EXIT_PANIC 8   /* Mark the receiving tealet as panic-resumed */
@@ -406,7 +405,7 @@ int tealet_switch(tealet_t *target, void **parg, int flags);
  * #TEALET_EXIT_DEFER.
  *
  * `return p;` from run() uses an implicit policy rooted in
- * `tealet_exit(p, NULL, TEALET_EXIT_DELETE)`, with retries for memory/defunct
+ * `tealet_exit(p, NULL, TEALET_EXIT_DEFAULT)`, with retries for memory/defunct
  * failures and a panic+force fallback to main.
  */
 TEALET_API

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -372,6 +372,8 @@ int tealet_fork(tealet_t *tealet, tealet_t **pother, void **parg, int flags);
  * #TEALET_SWITCH_NOFAIL applies retry/fallback policy: first attempt with
  * FORCE, then panic+force fallback to main only on #TEALET_ERR_MEM/
  * #TEALET_ERR_DEFUNCT. Other errors are returned unchanged.
+ * When @p target is main, #TEALET_SWITCH_NOFAIL is guaranteed to succeed,
+ * because main is never allowed to become defunct.
  *
  * @warning Do not pass stack-allocated cross-tealet payloads through @p parg.
  */
@@ -415,6 +417,8 @@ int tealet_switch(tealet_t *target, void **parg, int flags);
  * 1) requested target with #TEALET_EXIT_FORCE,
  * 2) panic+force fallback to main only on #TEALET_ERR_MEM/
  *    #TEALET_ERR_DEFUNCT. Other errors are returned unchanged.
+ * When @p target is main, #TEALET_EXIT_NOFAIL is guaranteed to succeed,
+ * because main is never allowed to become defunct.
  *
  * `return p;` from run() uses an implicit policy rooted in
  * `tealet_exit(p, NULL, TEALET_EXIT_DEFAULT)`, with retries for memory/defunct

--- a/tests/test_fork.c
+++ b/tests/test_fork.c
@@ -521,9 +521,10 @@ static void test_new_previous(void *far_marker) {
   assert(tealet_run(started, test_new_previous_run, &arg, NULL, TEALET_RUN_SWITCH) == 0);
 
   /* Verify tealet_previous() after return from tealet_run() */
-  /* Note: the tealet has already been freed at this point, so we just verify
-   * we're back in main */
+  /* With default return behavior, the started tealet remains allocated until
+   * explicitly deleted by the caller. */
   assert(tealet_current(main) == main);
+  tealet_delete(started);
   printf("  Main: returned from tealet_run(SWITCH), tealet_previous() test passed\n");
 
   finalize_main_checked(main);

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -421,13 +421,18 @@ static tealet_t *test_stack_far_isolation_parent(tealet_t *current, void *arg) {
   child = tealet_new_native(current, test_stack_far_isolation_run, &child_arg, stack_far);
   assert(child != NULL);
 
-  /* Child wrote to its own copied stack, parent value remains unchanged. */
+  /* Child already ran once during creation (RUN_SWITCH): it wrote its private
+   * copy and switched back to parent.
+   */
   assert(shared.value == 11);
 
+  /* Resume child: it confirms its private value, then returns/exits to main. */
   tealet_switch(child, NULL, TEALET_SWITCH_DEFAULT);
+
+  /* Child has exited; explicit delete is still required. */
   tealet_delete(child);
 
-  /* Child still observes its own modified value on resume. */
+  /* Parent value remains unchanged throughout. */
   assert(shared.value == 11);
   tealet_free(current, run_arg);
   return g_main;

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -425,6 +425,7 @@ static tealet_t *test_stack_far_isolation_parent(tealet_t *current, void *arg) {
   assert(shared.value == 11);
 
   tealet_switch(child, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_delete(child);
 
   /* Child still observes its own modified value on resume. */
   assert(shared.value == 11);
@@ -467,6 +468,7 @@ void test_stack_far_isolation(void) {
   init_test();
   parent = tealet_new_native(g_main, test_stack_far_isolation_parent, NULL, NULL);
   assert(parent != NULL);
+  tealet_delete(parent);
   fini_test();
 }
 
@@ -520,6 +522,7 @@ void test_simple(void) {
   t = tealet_new_native_call(g_main, test_simple_run, NULL, NULL);
   assert(t != NULL);
   assert(status == 1);
+  tealet_delete(t);
   fini_test();
 }
 
@@ -676,6 +679,8 @@ void test_simple_create_and_run(void) {
   assert(tealet_spawn(g_main, &t, test_simple_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
   tealet_switch(t, NULL, TEALET_SWITCH_DEFAULT);
   assert(status == 1);
+  assert(tealet_previous(g_main) == t);
+  tealet_delete(t);
   assert(tealet_previous(g_main) == NULL);
   fini_test();
 }
@@ -699,6 +704,8 @@ void test_create_previous(void) {
   /* Now switch to it - it should see main as previous */
   tealet_switch(t, NULL, TEALET_SWITCH_DEFAULT);
   assert(status == 42); /* Verify it ran */
+  assert(tealet_previous(g_main) == t);
+  tealet_delete(t);
   assert(tealet_previous(g_main) == NULL);
   fini_test();
 }
@@ -749,6 +756,7 @@ void test_status(void) {
   assert(tealet_status(stub1) == TEALET_STATUS_ACTIVE);
   assert(!TEALET_IS_MAIN(stub1));
   tealet_stub_run(stub1, test_status_run, NULL);
+  tealet_delete(stub1);
 
   fini_test();
 }
@@ -835,6 +843,8 @@ void test_switch(void) {
   init_test();
   assert(tealet_new_native_call(g_main, test_switch_1, NULL, NULL) != NULL);
   assert(status == 7);
+  tealet_delete(glob_t1);
+  tealet_delete(glob_t2);
   fini_test();
 }
 
@@ -855,6 +865,7 @@ void test_switch_self_panic(void) {
   runner = tealet_new_native_call(g_main, test_simple_run, NULL, NULL);
   assert(runner != NULL);
   assert(status == 1);
+  tealet_delete(runner);
 
   fini_test();
 }
@@ -904,7 +915,8 @@ void test_switch_new(void) {
   assert(tealet2 != NULL);
   assert(tealet_status(tealet2) == TEALET_STATUS_ACTIVE);
   tealet_switch(tealet2, NULL, TEALET_SWITCH_DEFAULT);
-  /* tealet should be dead now */
+  tealet_delete(tealet1);
+  tealet_delete(tealet2);
   fini_test();
 }
 
@@ -993,7 +1005,9 @@ tealet_t *random_new_tealet(tealet_t *cur, void *arg) {
     i = 0;
   }
   got_index = i;
-  return tealetarray[i];
+  tealet_exit(tealetarray[i], NULL, TEALET_EXIT_DELETE);
+  assert(0);
+  return NULL;
 }
 
 void test_random(void) {
@@ -1034,7 +1048,9 @@ tealet_t *random2_tealet(tealet_t *cur, void *arg) {
   tealetarray[index] = cur;
   random2_run(index);
   tealetarray[index] = NULL;
-  return tealetarray[0]; /* switch to main */
+  tealet_exit(tealetarray[0], NULL, TEALET_EXIT_DELETE); /* switch to main */
+  assert(0);
+  return NULL;
 }
 void random2_new(int index) {
   void *arg = (void *)(intptr_t)index;
@@ -1144,6 +1160,8 @@ void test_extra(void) {
   t2 = tealet_duplicate(t1);
   tealet_stub_run(t1, extra_tealet, NULL);
   tealet_stub_run(t2, extra_tealet, NULL);
+  tealet_delete(t2);
+  tealet_delete(t1);
   fini_test();
 }
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -426,7 +426,7 @@ static tealet_t *test_stack_far_isolation_parent(tealet_t *current, void *arg) {
    */
   assert(shared.value == 11);
 
-  /* Resume child: it confirms its private value, then returns/exits to main. */
+  /* Resume child: it confirms its private value, then returns/exits to parent. */
   tealet_switch(child, NULL, TEALET_SWITCH_DEFAULT);
 
   /* Child has exited; explicit delete is still required. */
@@ -568,7 +568,7 @@ static tealet_t *test_lock_transition_run(tealet_t *current, void *arg) {
   lock_snapshot_take(&g_lock_exit_before);
   g_lock_phase = LOCK_PHASE_DONE;
   tealet_exit(g_main, NULL, TEALET_EXIT_DELETE);
-  assert(0);
+  abort();
   return NULL;
 }
 
@@ -607,7 +607,7 @@ static tealet_t *test_lock_transition_stub_run(tealet_t *current, void *arg) {
   lock_snapshot_take(&g_lock_exit_before);
   g_lock_phase = LOCK_PHASE_DONE;
   tealet_exit(g_main, NULL, TEALET_EXIT_DELETE);
-  assert(0);
+  abort();
   return NULL;
 }
 
@@ -664,7 +664,7 @@ void test_lock_transitions_fork(void) {
   assert(result == 0);
   tealet_test_lock_assert_unheld(&g_lock_state);
   tealet_exit(other, NULL, 0);
-  assert(0);
+  abort();
 }
 
 void test_simple_create(void) {
@@ -772,7 +772,7 @@ tealet_t *test_exit_run(tealet_t *t1, void *arg) {
   assert(t1 != g_main);
   status += 1;
   result = tealet_exit(g_main, NULL, (int)(intptr_t)arg);
-  assert(0);
+  abort();
   assert(result == 0);
   return (tealet_t *)-1;
 }
@@ -1011,7 +1011,7 @@ tealet_t *random_new_tealet(tealet_t *cur, void *arg) {
   }
   got_index = i;
   tealet_exit(tealetarray[i], NULL, TEALET_EXIT_DELETE);
-  assert(0);
+  abort();
   return NULL;
 }
 
@@ -1054,7 +1054,7 @@ tealet_t *random2_tealet(tealet_t *cur, void *arg) {
   random2_run(index);
   tealetarray[index] = NULL;
   tealet_exit(tealetarray[0], NULL, TEALET_EXIT_DELETE); /* switch to main */
-  assert(0);
+  abort();
   return NULL;
 }
 void random2_new(int index) {
@@ -1222,7 +1222,7 @@ tealet_t *mem_error_tealet(tealet_t *t1, void *arg) {
   res = tealet_switch(peer, &myarg, TEALET_SWITCH_DEFAULT);
   assert(res == TEALET_ERR_MEM);
   tealet_exit(peer, myarg, TEALET_EXIT_DELETE);
-  assert(0); // never runs
+  abort(); // never runs
   return NULL;
 }
 
@@ -1248,7 +1248,7 @@ static tealet_t *oom_force_to_main_run(tealet_t *current, void *arg) {
 
   /* FORCE should continue by defuncting current and transferring out. */
   result = tealet_switch(current->main, NULL, TEALET_SWITCH_FORCE);
-  assert(0);
+  abort();
   assert(result == 0);
   return NULL;
 }
@@ -1317,7 +1317,7 @@ static tealet_t *oom_force_peer_to_main_panic_run(tealet_t *current, void *arg) 
   /* Clear allocator fault so this switch-out can complete. */
   talloc_fail = 0;
   result = tealet_switch(current->main, NULL, TEALET_SWITCH_PANIC);
-  assert(0);
+  abort();
   assert(result == TEALET_ERR_PANIC);
   return NULL;
 }
@@ -1330,7 +1330,7 @@ static tealet_t *oom_force_to_peer_run(tealet_t *current, void *arg) {
 
   talloc_fail = 1;
   result = tealet_switch(oom_w2, NULL, TEALET_SWITCH_FORCE);
-  assert(0);
+  abort();
   assert(result == 0);
   (void)current;
   return NULL;
@@ -1376,7 +1376,7 @@ static tealet_t *test_exit_self_invalid_run(tealet_t *current, void *arg) {
   assert(result == TEALET_ERR_INVAL);
 
   tealet_exit(current->main, NULL, TEALET_EXIT_DELETE);
-  assert(0);
+  abort();
   return NULL;
 }
 
@@ -1406,7 +1406,7 @@ static tealet_t *test_exit_defunct_fail_run(tealet_t *current, void *arg) {
   assert(result == TEALET_ERR_DEFUNCT);
 
   tealet_exit(current->main, NULL, TEALET_EXIT_DELETE);
-  assert(0);
+  abort();
   return NULL;
 }
 
@@ -1441,7 +1441,7 @@ static tealet_t *test_explicit_panic_exit_run(tealet_t *current, void *arg) {
 
   assert(current != g_main);
   tealet_exit(target, NULL, TEALET_EXIT_DELETE | TEALET_EXIT_PANIC);
-  assert(0);
+  abort();
   return NULL;
 }
 
@@ -1516,7 +1516,7 @@ static tealet_t *test_invalid_caller_check_child_run(tealet_t *current, void *ar
   assert(result == 0);
 
   tealet_exit(g_main, NULL, TEALET_EXIT_DELETE);
-  assert(0);
+  abort();
   return NULL;
 }
 


### PR DESCRIPTION
## Summary
- change implicit run-function return policy to keep tealets alive by default (TEALET_EXIT_DEFAULT)
- keep self-delete as an explicit opt-in via tealet_exit(..., TEALET_EXIT_DELETE)
- update tests to perform explicit cleanup where prior behavior assumed implicit deletion
- update docs/examples and API comments, including pointer invalidation note for TEALET_EXIT_DELETE
- add changelog entry under Unreleased

## Validation
- make test

## Notes
- this keeps ownership/lifetime explicit at call sites and avoids implicit destruction on normal run-function return