### PR TITLE
Add NOFAIL fallback policies for exit and switch

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -126,6 +126,26 @@ tealet_exit(target, arg, TEALET_EXIT_DEFER);    // Defer to return statement
 - `TEALET_ERR_DEFUNCT`: Target tealet is corrupt
 - Use `assert()` for debug builds
 
+### Validation and undefined behavior policy (review-critical)
+- Do not propose broad runtime argument/flag validation by default.
+- `TEALET_ERR_INVAL` exists primarily for application logic errors (for example,
+  wrong tealet object, wrong ownership/domain assumptions, or impossible call
+  context), not as a general "flag sanitizer" for every invalid bit pattern.
+- Unknown flag bits and undocumented flag combinations are intentionally
+  **undefined behavior** unless explicitly documented otherwise.
+- Keep public API docs focused on defined/supported behavior; do not expand API
+  docs to enumerate undefined behavior cases.
+- In reviews, avoid requesting extra checks or docs for undefined flag misuse
+  unless maintainers explicitly choose to define those semantics.
+
+### Test assertions policy (review-critical)
+- Files under `tests/` (including `tests/tests.c`) are run in debug-oriented
+  builds as part of this project's validation workflow.
+- In test code, `assert(0)` used to mark logically unreachable control-flow
+  paths is intentional and acceptable.
+- Do not request replacing such `assert(0)` calls with `abort()` by default;
+  treat them as test invariants unless maintainers explicitly ask otherwise.
+
 ## Important Warnings
 
 ### Stack Data Safety

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **NOFAIL transfer policies for both exit and switch APIs**
+  - Added `TEALET_EXIT_NOFAIL` and `TEALET_SWITCH_NOFAIL` to provide a
+    robustness-oriented transfer mode for callers that prioritize forward
+    progress under memory pressure/defunct-target conditions.
+
 ### Changed
 - **Creation semantics now use explicit allocation + bind/start steps**
   - `tealet_new()` now allocates and returns a NEW/unbound tealet handle.
@@ -17,10 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `tealet_fork()` now uses `TEALET_RUN_DEFAULT` / `TEALET_RUN_SWITCH`
     mode flags.
 
-- **Added NOFAIL transfer policies for both exit and switch APIs**
-  - Added `TEALET_EXIT_NOFAIL` and `TEALET_SWITCH_NOFAIL` to provide a
-    robustness-oriented transfer mode for callers that prioritize forward
-    progress under memory pressure/defunct-target conditions.
+- **NOFAIL transfer policy behavior and internals**
   - Both NOFAIL paths now use FORCE-first transfer attempts.
   - Fallback to `PANIC|FORCE` main transfer is limited to expected runtime
     failure classes (`TEALET_ERR_MEM` / `TEALET_ERR_DEFUNCT`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `tealet_fork()` now uses `TEALET_RUN_DEFAULT` / `TEALET_RUN_SWITCH`
     mode flags.
 
+- **Added NOFAIL transfer policies for both exit and switch APIs**
+  - Added `TEALET_EXIT_NOFAIL` and `TEALET_SWITCH_NOFAIL` to provide a
+    robustness-oriented transfer mode for callers that prioritize forward
+    progress under memory pressure/defunct-target conditions.
+  - Both NOFAIL paths now use FORCE-first transfer attempts.
+  - Fallback to `PANIC|FORCE` main transfer is limited to expected runtime
+    failure classes (`TEALET_ERR_MEM` / `TEALET_ERR_DEFUNCT`).
+  - Other errors (for example `TEALET_ERR_INVAL`, and `TEALET_ERR_PANIC` on
+    switch) are returned unchanged.
+  - Added internal invariant asserts in exit paths to document impossible
+    panic-return states from inner exit transfer helpers.
+
+- **Switch/exit NOFAIL implementation cleanup and docs alignment**
+  - Refactored switch flow around an internal helper (`tealet_switch_inner()`) to
+    keep retry/fallback behavior within a single lock scope.
+  - Added regression coverage for NOFAIL behavior under OOM/defunct scenarios in
+    `tests/tests.c`.
+  - Updated API docs (`src/tealet.h`, `docs/API.md`,
+    `docs/GETTING_STARTED.md`) to describe current NOFAIL behavior and clarify
+    assert-based debug invariants for API-misuse flag combinations/bits.
+
 ### Removed
 - **Legacy creation API surface removed from core**
   - Removed core `tealet_create()` and the old create-and-start `tealet_new(...)`

--- a/docs/API.md
+++ b/docs/API.md
@@ -1374,6 +1374,7 @@ Switch result signaling explicit panic-tagged resume.
 #define TEALET_SWITCH_DEFAULT 0  /* Default switch behavior */
 #define TEALET_SWITCH_FORCE   4  /* Force switch despite save-time memory failures */
 #define TEALET_SWITCH_PANIC   8  /* Mark receiving tealet as panic-resumed */
+#define TEALET_SWITCH_NOFAIL 16  /* Retry with FORCE, then panic+force to main */
 ```
 
 Used with `tealet_exit()`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -409,7 +409,7 @@ the trade-off for forward progress under memory pressure.
 
 `TEALET_SWITCH_NOFAIL` applies a robust retry/fallback policy: first try the
 requested target with `TEALET_SWITCH_FORCE`, then panic+force fallback to main
-for defunct or remaining failures.
+for `TEALET_ERR_MEM` / `TEALET_ERR_DEFUNCT` failures.
 See the detailed policy discussion and conceptual retry flow under
 `tealet_exit()` / `TEALET_EXIT_NOFAIL` below; `TEALET_SWITCH_NOFAIL` follows
 the same shape with switch flags.
@@ -418,6 +418,9 @@ the same shape with switch flags.
 legitimate switch-back signal (not a transfer failure to retry). In typical
 usage, panic-tagged fallbacks target main, so this check is usually needed on
 the main tealet's switch return path.
+
+**Debug invariant:** unknown `tealet_switch()` flag bits are treated as API
+misuse and asserted in debug builds.
 
 **Usage:**
 ```c
@@ -520,7 +523,10 @@ This function does not return on successful transfer.
 - Negative error code on failure
     - `TEALET_ERR_MEM` when save/restore cannot complete and `TEALET_EXIT_FORCE` is not set
     - `TEALET_ERR_DEFUNCT` when the requested target is defunct
-    - `TEALET_ERR_INVAL` for invalid flag combinations (for example `TEALET_EXIT_DEFER | TEALET_EXIT_PANIC`)
+    - `TEALET_ERR_INVAL` for invalid target/state
+
+**Debug invariant:** `TEALET_EXIT_DEFER | TEALET_EXIT_PANIC` (or unknown flag
+bits) is treated as API misuse and asserted in debug builds.
 
 `tealet_exit()` does not implicitly reroute to another target.
 
@@ -535,7 +541,9 @@ continue would require main-stack growth that fails under memory pressure.
 `TEALET_EXIT_NOFAIL` applies the same robust fallback policy used by implicit
 run-function return handling:
 - try requested target with `TEALET_EXIT_FORCE`
-- reroute to main with `TEALET_EXIT_PANIC | TEALET_EXIT_FORCE` when transfer still cannot complete
+- reroute to main with `TEALET_EXIT_PANIC | TEALET_EXIT_FORCE` only on
+    `TEALET_ERR_MEM` / `TEALET_ERR_DEFUNCT`
+- return other errors unchanged
 Main is never marked defunct, so this edge case remains a hard memory failure.
 
 This means a successful forced exit can make other tealets become defunct as

--- a/docs/API.md
+++ b/docs/API.md
@@ -323,7 +323,7 @@ int main(void) {
         
         /* CRITICAL: Forked tealets MUST use tealet_exit() */
         void *return_value = (void*)0x1234;
-        tealet_exit(other, return_value, 0);  /* Switch back to parent */
+        tealet_exit(other, return_value, TEALET_EXIT_NOFAIL);  /* Switch back to parent */
         
         /* Should not reach here */
         abort();
@@ -469,6 +469,7 @@ Exit current tealet and transfer control to target.
   tealet exits later.
 - `TEALET_EXIT_FORCE`: Force the requested transfer despite save-time memory pressure by defuncting affected non-main stacks as needed
 - `TEALET_EXIT_PANIC`: Tag the receiving tealet's resumed switch return as `TEALET_ERR_PANIC`
+- `TEALET_EXIT_NOFAIL`: Apply automatic retries (`FORCE`, then `PANIC|FORCE` to main fallback)
 
 **Usage:**
 ```c
@@ -476,7 +477,7 @@ tealet_t *my_run(tealet_t *current, void *arg) {
     /* Do work */
     
     /* Exit and delete this tealet */
-    tealet_exit(current->main, &result, TEALET_EXIT_DELETE);
+    tealet_exit(current->main, &result, TEALET_EXIT_DELETE | TEALET_EXIT_NOFAIL);
     
     /* Never reached */
 }
@@ -518,6 +519,12 @@ This function does not return on successful transfer.
 
 `TEALET_EXIT_FORCE` can still return `TEALET_ERR_MEM` when the only way to
 continue would require main-stack growth that fails under memory pressure.
+
+`TEALET_EXIT_NOFAIL` applies the same robust fallback policy used by implicit
+run-function return handling:
+- try requested target in fail-fast mode
+- retry requested target with `TEALET_EXIT_FORCE` on `TEALET_ERR_MEM`
+- reroute to main with `TEALET_EXIT_PANIC | TEALET_EXIT_FORCE` when retries still cannot complete
 Main is never marked defunct, so this edge case remains a hard memory failure.
 
 This means a successful forced exit can make other tealets become defunct as
@@ -530,10 +537,10 @@ if FORCE still fails (including the main-stack edge above), panic+force to main.
 Use `tealet_exit()` when you need explicit control over deletion or want to
 exit from nested calls within the run function.
 
-**Manual robust `tealet_exit()` pattern (equivalent intent):**
+**Robust retry policy used by `TEALET_EXIT_NOFAIL` (conceptual flow):**
 ```c
 /* Non-returning helper. abort() documents unreachable return. */
-static void robust_exit(tealet_t *self, tealet_t *target, void *arg, int base_flags) {
+static void exit_nofail_policy(tealet_t *self, tealet_t *target, void *arg, int base_flags) {
     int r;
 
     /* 1) Fast path: requested target, caller policy flags. */
@@ -548,16 +555,28 @@ static void robust_exit(tealet_t *self, tealet_t *target, void *arg, int base_fl
     /* 3) Memory pressure: retry requested target with FORCE. */
     if (r == TEALET_ERR_MEM) {
         r = tealet_exit(target, arg, base_flags | TEALET_EXIT_FORCE);
-
-        /* 4) FORCE may still fail in main-stack growth edge case. */
-        if (r == TEALET_ERR_MEM || r == TEALET_ERR_DEFUNCT) {
+        if (r < 0) {
+            /* 4) Any remaining failure: panic+force to main. */
             (void)tealet_exit(self->main, arg, base_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE);
             abort();
         }
     }
 
+    if (r < 0) {
+        /* 5) Non-mem/non-defunct failures also route to panic+force main. */
+        (void)tealet_exit(self->main, arg, base_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE);
+        abort();
+    }
+
     abort();
 }
+```
+
+In normal code, prefer the built-in helper policy directly:
+
+```c
+tealet_exit(target, arg, base_flags | TEALET_EXIT_NOFAIL);
+/* Non-returning on success */
 ```
 
 ---
@@ -1344,6 +1363,9 @@ Switch result signaling explicit panic-tagged resume.
 #define TEALET_EXIT_DEFAULT 0  /* Don't auto-delete */
 #define TEALET_EXIT_DELETE  1  /* Auto-delete on exit */
 #define TEALET_EXIT_DEFER   2  /* Defer exit to return */
+#define TEALET_EXIT_FORCE   4  /* Force exit despite save-time memory failures */
+#define TEALET_EXIT_PANIC   8  /* Mark receiving tealet as panic-resumed */
+#define TEALET_EXIT_NOFAIL 16  /* Retry with FORCE, then panic+force to main */
 
 /* Switch flags */
 #define TEALET_SWITCH_DEFAULT 0  /* Default switch behavior */
@@ -1423,7 +1445,7 @@ tealet_t *nested_run(tealet_t *current, void *arg) {
 void helper(tealet_t *current) {
     if (error_condition) {
         void *error = make_error();
-        tealet_exit(current->main, &error, TEALET_EXIT_DELETE);
+        tealet_exit(current->main, &error, TEALET_EXIT_DELETE | TEALET_EXIT_NOFAIL);
         /* Never returns */
     }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -419,8 +419,10 @@ legitimate switch-back signal (not a transfer failure to retry). In typical
 usage, panic-tagged fallbacks target main, so this check is usually needed on
 the main tealet's switch return path.
 
-**Debug invariant:** unknown `tealet_switch()` flag bits are treated as API
-misuse and asserted in debug builds.
+Unknown `tealet_switch()` flag bits return `TEALET_ERR_INVAL`.
+
+**Debug invariant:** unknown `tealet_switch()` flag bits are also asserted in
+debug builds.
 
 **Usage:**
 ```c
@@ -525,8 +527,11 @@ This function does not return on successful transfer.
     - `TEALET_ERR_DEFUNCT` when the requested target is defunct
     - `TEALET_ERR_INVAL` for invalid target/state
 
-**Debug invariant:** `TEALET_EXIT_DEFER | TEALET_EXIT_PANIC` (or unknown flag
-bits) is treated as API misuse and asserted in debug builds.
+`TEALET_EXIT_DEFER | TEALET_EXIT_PANIC` (and unknown exit flag bits) return
+`TEALET_ERR_INVAL`.
+
+**Debug invariant:** these invalid flag combinations/bits are also asserted in
+debug builds.
 
 `tealet_exit()` does not implicitly reroute to another target.
 
@@ -550,9 +555,9 @@ This means a successful forced exit can make other tealets become defunct as
 the trade-off for forward progress under memory pressure.
 
 **Note:** Returning from the run function automatically deletes the tealet using
-an implicit `tealet_exit()` policy: try requested target with FORCE and, if that
-fails (including defunct target or the main-stack memory edge above), panic+force
-to main.
+an implicit `tealet_exit()` policy:
+- first run `TEALET_EXIT_NOFAIL` with delete semantics
+- if that still fails for any reason, panic+force to main
 Use `tealet_exit()` when you need explicit control over deletion or want to
 exit from nested calls within the run function.
 
@@ -565,13 +570,14 @@ static void exit_nofail_policy(tealet_t *self, tealet_t *target, void *arg, int 
     /* 1) First attempt: requested target, FORCE enabled. */
     r = tealet_exit(target, arg, base_flags | TEALET_EXIT_FORCE);
 
-    if (r < 0) {
-        /* 2) Any failure: panic+force fallback to main. */
+    if (r == TEALET_ERR_MEM || r == TEALET_ERR_DEFUNCT) {
+        /* 2) Robustness failures: panic+force fallback to main. */
         (void)tealet_exit(self->main, arg, base_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE);
         abort();
     }
 
-    abort();
+    /* 3) Other failures are returned unchanged by NOFAIL. */
+    return;
 }
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -419,11 +419,6 @@ legitimate switch-back signal (not a transfer failure to retry). In typical
 usage, panic-tagged fallbacks target main, so this check is usually needed on
 the main tealet's switch return path.
 
-Unknown `tealet_switch()` flag bits return `TEALET_ERR_INVAL`.
-
-**Debug invariant:** unknown `tealet_switch()` flag bits are also asserted in
-debug builds.
-
 **Usage:**
 ```c
 void *arg = my_data;
@@ -527,12 +522,6 @@ This function does not return on successful transfer.
     - `TEALET_ERR_DEFUNCT` when the requested target is defunct
     - `TEALET_ERR_INVAL` for invalid target/state
 
-`TEALET_EXIT_DEFER | TEALET_EXIT_PANIC` (and unknown exit flag bits) return
-`TEALET_ERR_INVAL`.
-
-**Debug invariant:** these invalid flag combinations/bits are also asserted in
-debug builds.
-
 `tealet_exit()` does not implicitly reroute to another target.
 
 `TEALET_EXIT_FORCE` mirrors `TEALET_SWITCH_FORCE` behavior:
@@ -556,8 +545,7 @@ the trade-off for forward progress under memory pressure.
 
 **Note:** Returning from the run function automatically deletes the tealet using
 an implicit `tealet_exit()` policy:
-- first run `TEALET_EXIT_NOFAIL` with delete semantics
-- if that still fails for any reason, panic+force to main
+- run `TEALET_EXIT_NOFAIL` with delete semantics
 Use `tealet_exit()` when you need explicit control over deletion or want to
 exit from nested calls within the run function.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -551,8 +551,8 @@ exit from nested calls within the run function.
 
 **Robust retry policy used by `TEALET_EXIT_NOFAIL` (conceptual flow):**
 ```c
-/* Non-returning helper. abort() documents unreachable return. */
-static void exit_nofail_policy(tealet_t *self, tealet_t *target, void *arg, int base_flags) {
+/* Conceptual helper: return non-robustness failures unchanged. */
+static int exit_nofail_policy(tealet_t *self, tealet_t *target, void *arg, int base_flags) {
     int r;
 
     /* 1) First attempt: requested target, FORCE enabled. */
@@ -565,7 +565,7 @@ static void exit_nofail_policy(tealet_t *self, tealet_t *target, void *arg, int 
     }
 
     /* 3) Other failures are returned unchanged by NOFAIL. */
-    return;
+    return r;
 }
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -385,7 +385,7 @@ Suspend current tealet and resume target tealet.
 **Parameters:**
 - `target`: Tealet to switch to
 - `parg`: Pointer to argument pointer (passed to target, updated with return value)
-- `flags`: Switch control flags (`TEALET_SWITCH_DEFAULT`, `TEALET_SWITCH_FORCE`, `TEALET_SWITCH_PANIC`)
+- `flags`: Switch control flags (`TEALET_SWITCH_DEFAULT`, `TEALET_SWITCH_FORCE`, `TEALET_SWITCH_PANIC`, `TEALET_SWITCH_NOFAIL`)
 
 **Returns:** 
 - `0` on success
@@ -406,6 +406,14 @@ Main is never marked defunct, so this edge case remains a hard memory failure.
 
 This means a successful forced switch can make other tealets become defunct as
 the trade-off for forward progress under memory pressure.
+
+`TEALET_SWITCH_NOFAIL` applies a robust retry/fallback policy: try the
+requested target with caller flags, retry the requested target with
+`TEALET_SWITCH_FORCE` on `TEALET_ERR_MEM`, and panic+force fallback to main
+for defunct or remaining failures.
+See the detailed policy discussion and conceptual retry flow under
+`tealet_exit()` / `TEALET_EXIT_NOFAIL` below; `TEALET_SWITCH_NOFAIL` follows
+the same shape with switch flags.
 
 **Usage:**
 ```c

--- a/docs/API.md
+++ b/docs/API.md
@@ -407,13 +407,17 @@ Main is never marked defunct, so this edge case remains a hard memory failure.
 This means a successful forced switch can make other tealets become defunct as
 the trade-off for forward progress under memory pressure.
 
-`TEALET_SWITCH_NOFAIL` applies a robust retry/fallback policy: try the
-requested target with caller flags, retry the requested target with
-`TEALET_SWITCH_FORCE` on `TEALET_ERR_MEM`, and panic+force fallback to main
+`TEALET_SWITCH_NOFAIL` applies a robust retry/fallback policy: first try the
+requested target with `TEALET_SWITCH_FORCE`, then panic+force fallback to main
 for defunct or remaining failures.
 See the detailed policy discussion and conceptual retry flow under
 `tealet_exit()` / `TEALET_EXIT_NOFAIL` below; `TEALET_SWITCH_NOFAIL` follows
 the same shape with switch flags.
+
+`TEALET_SWITCH_NOFAIL` can still return `TEALET_ERR_PANIC`, because panic is a
+legitimate switch-back signal (not a transfer failure to retry). In typical
+usage, panic-tagged fallbacks target main, so this check is usually needed on
+the main tealet's switch return path.
 
 **Usage:**
 ```c
@@ -530,18 +534,17 @@ continue would require main-stack growth that fails under memory pressure.
 
 `TEALET_EXIT_NOFAIL` applies the same robust fallback policy used by implicit
 run-function return handling:
-- try requested target in fail-fast mode
-- retry requested target with `TEALET_EXIT_FORCE` on `TEALET_ERR_MEM`
-- reroute to main with `TEALET_EXIT_PANIC | TEALET_EXIT_FORCE` when retries still cannot complete
+- try requested target with `TEALET_EXIT_FORCE`
+- reroute to main with `TEALET_EXIT_PANIC | TEALET_EXIT_FORCE` when transfer still cannot complete
 Main is never marked defunct, so this edge case remains a hard memory failure.
 
 This means a successful forced exit can make other tealets become defunct as
 the trade-off for forward progress under memory pressure.
 
 **Note:** Returning from the run function automatically deletes the tealet using
-an implicit `tealet_exit()` policy: try requested target, panic+force to main
-if target is defunct, retry requested target with FORCE on memory failure, and
-if FORCE still fails (including the main-stack edge above), panic+force to main.
+an implicit `tealet_exit()` policy: try requested target with FORCE and, if that
+fails (including defunct target or the main-stack memory edge above), panic+force
+to main.
 Use `tealet_exit()` when you need explicit control over deletion or want to
 exit from nested calls within the run function.
 
@@ -551,27 +554,11 @@ exit from nested calls within the run function.
 static void exit_nofail_policy(tealet_t *self, tealet_t *target, void *arg, int base_flags) {
     int r;
 
-    /* 1) Fast path: requested target, caller policy flags. */
-    r = tealet_exit(target, arg, base_flags);
-
-    /* 2) Defunct target: panic+force fallback to main. */
-    if (r == TEALET_ERR_DEFUNCT) {
-        (void)tealet_exit(self->main, arg, base_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE);
-        abort();
-    }
-
-    /* 3) Memory pressure: retry requested target with FORCE. */
-    if (r == TEALET_ERR_MEM) {
-        r = tealet_exit(target, arg, base_flags | TEALET_EXIT_FORCE);
-        if (r < 0) {
-            /* 4) Any remaining failure: panic+force to main. */
-            (void)tealet_exit(self->main, arg, base_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE);
-            abort();
-        }
-    }
+    /* 1) First attempt: requested target, FORCE enabled. */
+    r = tealet_exit(target, arg, base_flags | TEALET_EXIT_FORCE);
 
     if (r < 0) {
-        /* 5) Non-mem/non-defunct failures also route to panic+force main. */
+        /* 2) Any failure: panic+force fallback to main. */
         (void)tealet_exit(self->main, arg, base_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE);
         abort();
     }

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -161,7 +161,7 @@ tealet_t *my_run(tealet_t *current, void *arg) {
     printf("Doing work...\n");
     
     /* ✅ Recommended: Explicit exit */
-    tealet_exit(current->main, NULL, TEALET_EXIT_DELETE);
+    tealet_exit(current->main, NULL, TEALET_EXIT_DELETE | TEALET_EXIT_NOFAIL);
     
     /* Should not reach here */
     return current->main;  /* Fallback only */
@@ -210,7 +210,7 @@ int main(void) {
 tealet_t *worker_run(tealet_t *current, void *arg) {
     printf("Work done\n");
     /* Exit without auto-delete */
-    tealet_exit(current->main, NULL, TEALET_EXIT_DEFAULT);
+    tealet_exit(current->main, NULL, TEALET_EXIT_DEFAULT | TEALET_EXIT_NOFAIL);
     return current->main;
 }
 
@@ -239,6 +239,7 @@ int main(void) {
 - `TEALET_EXIT_DEFAULT` (0): **Prevent auto-delete**; tealet must be manually deleted with `tealet_delete()`
 - `TEALET_EXIT_DELETE`: **Auto-delete on exit**; same as returning from the run function (the default behavior)
 - `TEALET_EXIT_DEFER`: **Defer deletion to run function return** (advanced; see API docs)
+- `TEALET_EXIT_NOFAIL`: **Enable robust fallback retries** when you intentionally do not check `tealet_exit()` return values
 
 **Note:** The old `TEALET_FLAG_*` names are still available for backwards compatibility.
 
@@ -270,7 +271,7 @@ tealet_t *controlled_worker(tealet_t *current, void *arg) {
         do_work();
         tealet_switch(current->main, NULL, TEALET_SWITCH_DEFAULT);  /* Yield back */
     }
-    tealet_exit(current->main, NULL, TEALET_EXIT_DEFAULT);  /* Don't auto-delete */
+    tealet_exit(current->main, NULL, TEALET_EXIT_DEFAULT | TEALET_EXIT_NOFAIL);  /* Don't auto-delete */
     return current->main;
 }
 

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1829,19 +1829,10 @@ int tealet_switch(tealet_t *stub, void **parg, int flags) {
   flags_used = flags;
   if (flags_used & TEALET_SWITCH_NOFAIL) {
     flags_used &= ~TEALET_SWITCH_NOFAIL;
+    retry_flags = flags_used | TEALET_SWITCH_FORCE;
 
-    result = tealet_switch_inner(stub, parg, flags_used);
-    if (result == TEALET_ERR_DEFUNCT) {
-      retry_flags = flags_used | TEALET_SWITCH_PANIC | TEALET_SWITCH_FORCE;
-      result = tealet_switch_inner((tealet_t *)g_main, parg, retry_flags);
-    } else if (result == TEALET_ERR_MEM) {
-      retry_flags = flags_used | TEALET_SWITCH_FORCE;
-      result = tealet_switch_inner(stub, parg, retry_flags);
-      if (result < 0) {
-        retry_flags = flags_used | TEALET_SWITCH_PANIC | TEALET_SWITCH_FORCE;
-        result = tealet_switch_inner((tealet_t *)g_main, parg, retry_flags);
-      }
-    } else if (result < 0) {
+    result = tealet_switch_inner(stub, parg, retry_flags);
+    if (result < 0 && result != TEALET_ERR_PANIC) {
       retry_flags = flags_used | TEALET_SWITCH_PANIC | TEALET_SWITCH_FORCE;
       result = tealet_switch_inner((tealet_t *)g_main, parg, retry_flags);
     }
@@ -1935,19 +1926,10 @@ int tealet_exit(tealet_t *target, void *arg, int flags) {
   flags_used = flags;
   if (flags_used & TEALET_EXIT_NOFAIL) {
     flags_used &= ~TEALET_EXIT_NOFAIL;
+    retry_flags = flags_used | TEALET_EXIT_FORCE;
 
-    result = tealet_exit_inner(target, arg, flags_used);
-    if (result == TEALET_ERR_DEFUNCT) {
-      retry_flags = flags_used | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
-      result = tealet_exit_inner((tealet_t *)g_main, arg, retry_flags);
-    } else if (result == TEALET_ERR_MEM) {
-      retry_flags = flags_used | TEALET_EXIT_FORCE;
-      result = tealet_exit_inner(target, arg, retry_flags);
-      if (result < 0) {
-        retry_flags = flags_used | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
-        result = tealet_exit_inner((tealet_t *)g_main, arg, retry_flags);
-      }
-    } else if (result < 0) {
+    result = tealet_exit_inner(target, arg, retry_flags);
+    if (result < 0) {
       retry_flags = flags_used | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
       result = tealet_exit_inner((tealet_t *)g_main, arg, retry_flags);
     }

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1367,6 +1367,7 @@ static void tealet_unlock_switch(tealet_main_t *g_main) {
 static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet_sub_t *g_target, tealet_run_t run,
                               void **parg, void *stack_far) {
   int result;
+  int fallback_flags;
   tealet_sub_t *g_exit_target;
   int exit_flags;
   void *exit_arg;
@@ -1439,6 +1440,13 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
     }
 
     result = tealet_exit((tealet_t *)g_exit_target, exit_arg, exit_flags | TEALET_EXIT_NOFAIL);
+    if (result < 0) {
+      /* Preserve implicit-return robustness: if requested transfer still
+       * fails (for example invalid target), panic+force to main.
+       */
+      fallback_flags = (exit_flags & ~TEALET_EXIT_NOFAIL) | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
+      result = tealet_exit((tealet_t *)g_main, exit_arg, fallback_flags);
+    }
     (void)result;
     assert(!"Implicit return transfer failed");
     abort();
@@ -1814,12 +1822,16 @@ static int tealet_switch_inner(tealet_t *stub, void **parg, int flags) {
 int tealet_switch(tealet_t *stub, void **parg, int flags) {
   tealet_sub_t *g_target = (tealet_sub_t *)stub;
   tealet_sub_t *g_current;
+  int allowed_flags;
   int flags_used;
   int retry_flags;
   int result;
   tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
 
-  assert((flags & ~(TEALET_SWITCH_FORCE | TEALET_SWITCH_PANIC | TEALET_SWITCH_NOFAIL)) == 0);
+  allowed_flags = TEALET_SWITCH_FORCE | TEALET_SWITCH_PANIC | TEALET_SWITCH_NOFAIL;
+  assert((flags & ~allowed_flags) == 0);
+  if ((flags & ~allowed_flags) != 0)
+    return TEALET_ERR_INVAL;
 
   g_current = g_main->g_current;
   tealet_verify_current_matches_caller(g_current);
@@ -1891,13 +1903,18 @@ int tealet_exit(tealet_t *target, void *arg, int flags) {
   tealet_sub_t *g_target = (tealet_sub_t *)target;
   tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
   tealet_sub_t *g_current;
+  int allowed_flags;
   int flags_used;
   int retry_flags;
   int result;
 
-  assert((flags &
-          ~(TEALET_EXIT_DELETE | TEALET_EXIT_DEFER | TEALET_EXIT_FORCE | TEALET_EXIT_PANIC | TEALET_EXIT_NOFAIL)) == 0);
+  allowed_flags = TEALET_EXIT_DELETE | TEALET_EXIT_DEFER | TEALET_EXIT_FORCE | TEALET_EXIT_PANIC | TEALET_EXIT_NOFAIL;
+  assert((flags & ~allowed_flags) == 0);
   assert(!((flags & TEALET_EXIT_DEFER) && (flags & TEALET_EXIT_PANIC)));
+  if ((flags & ~allowed_flags) != 0)
+    return TEALET_ERR_INVAL;
+  if ((flags & TEALET_EXIT_DEFER) && (flags & TEALET_EXIT_PANIC))
+    return TEALET_ERR_INVAL;
 
   g_current = g_main->g_current;
   tealet_verify_current_matches_caller(g_current);

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1370,7 +1370,6 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
   tealet_sub_t *g_exit_target;
   int exit_flags;
   void *exit_arg;
-  int retry_flags;
   int run_on_switch = g_new == g_target; /* true for tealet_run(..., TEALET_RUN_SWITCH) */
   void *run_arg, *switch_arg;
   void *initial_run_arg;
@@ -1427,10 +1426,8 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
     tealet_unlock_switch(g_main);
     g_exit_target = (tealet_sub_t *)(run((tealet_t *)g_main->g_current, run_arg));
 
-    /* Resolve any deferred-exit state explicitly so retries below use a
-     * single consistent (target,arg,flags) policy.
-     * Note: DEFER+FORCE is redundant in this implicit return path because a
-     * TEALET_ERR_MEM retry always adds FORCE anyway.
+    /* Resolve any deferred-exit state explicitly so implicit return uses one
+     * consistent (target,arg,flags) policy.
      */
     exit_flags = TEALET_EXIT_DELETE;
     exit_arg = NULL;
@@ -1441,28 +1438,8 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
       g_main->g_arg = NULL;
     }
 
-    /* Implicit return policy from run():
-     * 1) Try requested target in fail-fast mode.
-     * 2) If target is defunct, panic to main explicitly.
-     * 3) If memory blocked the transfer, retry requested target with FORCE.
-     * 4) If FORCE still cannot complete (for example main-stack growth would
-     *    be required and main cannot be marked defunct), panic+force to main.
-     */
-    result = tealet_exit((tealet_t *)g_exit_target, exit_arg, exit_flags);
-    if (result == TEALET_ERR_DEFUNCT) {
-      retry_flags = exit_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
-      result = tealet_exit((tealet_t *)g_main, exit_arg, retry_flags);
-    } else if (result == TEALET_ERR_MEM) {
-      retry_flags = exit_flags | TEALET_EXIT_FORCE;
-      result = tealet_exit((tealet_t *)g_exit_target, exit_arg, retry_flags);
-      if (result < 0) {
-        retry_flags = exit_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
-        result = tealet_exit((tealet_t *)g_main, exit_arg, retry_flags);
-      }
-    } else if (result < 0) {
-      retry_flags = exit_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
-      result = tealet_exit((tealet_t *)g_main, exit_arg, retry_flags);
-    }
+    result = tealet_exit((tealet_t *)g_exit_target, exit_arg, exit_flags | TEALET_EXIT_NOFAIL);
+    (void)result;
     assert(!"Implicit return transfer failed");
     abort();
   } else {
@@ -1847,9 +1824,8 @@ static int tealet_exit_inner(tealet_t *target, void *arg, int flags) {
   tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
   tealet_sub_t *g_current = g_main->g_current;
   char *stack_far = g_target->stack_far;
+  int panic_requested;
   int result;
-
-  tealet_verify_current_matches_caller(g_current);
 
   assert(g_current != (tealet_sub_t *)g_main); /* mustn't exit main */
   if (g_target == g_current)
@@ -1860,12 +1836,17 @@ static int tealet_exit_inner(tealet_t *target, void *arg, int flags) {
   g_current->flags |= TEALET_TFLAGS_EXITING;
   if (flags & TEALET_EXIT_FORCE)
     g_current->flags |= TEALET_TFLAGS_EXITFORCE;
+  panic_requested = ((flags & TEALET_EXIT_PANIC) != 0);
+  if (panic_requested)
+    g_main->g_flags |= TEALET_MFLAGS_PANIC;
   assert(g_current->stack == NULL);
   assert((g_current->flags & TEALET_TFLAGS_AUTODELETE) == 0);
   if (flags & TEALET_EXIT_DELETE)
     g_current->flags |= TEALET_TFLAGS_AUTODELETE;
   result = tealet_switchstack(g_main, g_target, arg, NULL);
   assert(result < 0); /* only return here if there was failure */
+  if (panic_requested)
+    g_main->g_flags &= ~TEALET_MFLAGS_PANIC;
   g_target->stack_far = stack_far;
   g_current->stack = NULL;
   g_current->flags &= ~(TEALET_TFLAGS_EXITING | TEALET_TFLAGS_AUTODELETE | TEALET_TFLAGS_EXITFORCE);
@@ -1883,28 +1864,30 @@ static int tealet_exit_inner(tealet_t *target, void *arg, int flags) {
 int tealet_exit(tealet_t *target, void *arg, int flags) {
   tealet_sub_t *g_target = (tealet_sub_t *)target;
   tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
+  tealet_sub_t *g_current;
   int flags_used;
-  int panic_requested;
+  int retry_flags;
   int result;
 
-  if ((flags & ~(TEALET_EXIT_DELETE | TEALET_EXIT_DEFER | TEALET_EXIT_FORCE | TEALET_EXIT_PANIC)) != 0) {
-    return TEALET_ERR_INVAL;
-  }
-  if ((flags & TEALET_EXIT_DEFER) && (flags & TEALET_EXIT_PANIC)) {
-    return TEALET_ERR_INVAL;
-  }
+  assert((flags & ~(TEALET_EXIT_DELETE | TEALET_EXIT_DEFER | TEALET_EXIT_FORCE | TEALET_EXIT_PANIC | TEALET_EXIT_NOFAIL)) ==
+         0);
+  assert(!((flags & TEALET_EXIT_DEFER) && (flags & TEALET_EXIT_PANIC)));
 
+  g_current = g_main->g_current;
+  tealet_verify_current_matches_caller(g_current);
+  
   tealet_lock_switch(g_main);
+  
   if (flags & TEALET_EXIT_DEFER) {
     /* setting up arg and flags for the run() return value */
     /* We temporarily borrow g_flags/g_arg storage on main until the
-     * deferred exit is consummated.
-     */
-    assert(g_main->g_flags == 0);
-    g_main->g_arg = arg;
-    g_main->g_flags = flags;
-    tealet_unlock_switch(g_main);
-    return 0; /* deferred exit, we are done here */
+    * deferred exit is consummated.
+    */
+   assert(g_main->g_flags == 0);
+   g_main->g_arg = arg;
+   g_main->g_flags = flags;
+   tealet_unlock_switch(g_main);
+   return 0; /* deferred exit, we are done here */
   }
   if (g_main->g_flags & TEALET_EXIT_DEFER) {
     /* Called second time (e.g. from return of run())
@@ -1916,15 +1899,28 @@ int tealet_exit(tealet_t *target, void *arg, int flags) {
     g_main->g_arg = 0;
   }
   flags_used = flags;
-  panic_requested = ((flags_used & TEALET_EXIT_PANIC) != 0);
-  if (panic_requested)
-    g_main->g_flags |= TEALET_MFLAGS_PANIC;
+  if (flags_used & TEALET_EXIT_NOFAIL) {
+    flags_used &= ~TEALET_EXIT_NOFAIL;
 
-  result = tealet_exit_inner(target, arg, flags_used);
-  assert(result < 0);
-
-  if (panic_requested)
-    g_main->g_flags &= ~TEALET_MFLAGS_PANIC;
+    result = tealet_exit_inner(target, arg, flags_used);
+    if (result == TEALET_ERR_DEFUNCT) {
+      retry_flags = flags_used | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
+      result = tealet_exit_inner((tealet_t *)g_main, arg, retry_flags);
+    } else if (result == TEALET_ERR_MEM) {
+      retry_flags = flags_used | TEALET_EXIT_FORCE;
+      result = tealet_exit_inner(target, arg, retry_flags);
+      if (result < 0) {
+        retry_flags = flags_used | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
+        result = tealet_exit_inner((tealet_t *)g_main, arg, retry_flags);
+      }
+    } else if (result < 0) {
+      retry_flags = flags_used | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
+      result = tealet_exit_inner((tealet_t *)g_main, arg, retry_flags);
+    }
+  } else {
+    result = tealet_exit_inner(target, arg, flags_used);
+    assert(result < 0);
+  }
 
   tealet_unlock_switch(g_main);
   return result;

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1777,26 +1777,19 @@ done:
  * the lock internally.
  */
 
-int tealet_switch(tealet_t *stub, void **parg, int flags) {
+static int tealet_switch_inner(tealet_t *stub, void **parg, int flags) {
   tealet_sub_t *g_target = (tealet_sub_t *)stub;
-  tealet_sub_t *g_current;
+  tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
+  tealet_sub_t *g_current = g_main->g_current;
   int force_requested;
   int panic_requested;
   int result;
-  tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
-
-  if ((flags & ~(TEALET_SWITCH_FORCE | TEALET_SWITCH_PANIC)) != 0)
-    return TEALET_ERR_INVAL;
 
   if ((g_target->flags & TEALET_TFLAGS_BOUND) == 0)
     return TEALET_ERR_INVAL;
 
   force_requested = ((flags & TEALET_SWITCH_FORCE) != 0);
   panic_requested = ((flags & TEALET_SWITCH_PANIC) != 0);
-
-  tealet_lock_switch(g_main);
-  g_current = g_main->g_current;
-  tealet_verify_current_matches_caller(g_current);
 
   if (force_requested)
     g_current->flags |= TEALET_TFLAGS_EXITFORCE;
@@ -1814,6 +1807,47 @@ int tealet_switch(tealet_t *stub, void **parg, int flags) {
     g_main->g_flags &= ~TEALET_MFLAGS_PANIC;
   if (force_requested)
     g_current->flags &= ~TEALET_TFLAGS_EXITFORCE;
+
+  return result;
+}
+
+int tealet_switch(tealet_t *stub, void **parg, int flags) {
+  tealet_sub_t *g_target = (tealet_sub_t *)stub;
+  tealet_sub_t *g_current;
+  int flags_used;
+  int retry_flags;
+  int result;
+  tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
+
+  if ((flags & ~(TEALET_SWITCH_FORCE | TEALET_SWITCH_PANIC | TEALET_SWITCH_NOFAIL)) != 0)
+    return TEALET_ERR_INVAL;
+
+  g_current = g_main->g_current;
+  tealet_verify_current_matches_caller(g_current);
+  tealet_lock_switch(g_main);
+
+  flags_used = flags;
+  if (flags_used & TEALET_SWITCH_NOFAIL) {
+    flags_used &= ~TEALET_SWITCH_NOFAIL;
+
+    result = tealet_switch_inner(stub, parg, flags_used);
+    if (result == TEALET_ERR_DEFUNCT) {
+      retry_flags = flags_used | TEALET_SWITCH_PANIC | TEALET_SWITCH_FORCE;
+      result = tealet_switch_inner((tealet_t *)g_main, parg, retry_flags);
+    } else if (result == TEALET_ERR_MEM) {
+      retry_flags = flags_used | TEALET_SWITCH_FORCE;
+      result = tealet_switch_inner(stub, parg, retry_flags);
+      if (result < 0) {
+        retry_flags = flags_used | TEALET_SWITCH_PANIC | TEALET_SWITCH_FORCE;
+        result = tealet_switch_inner((tealet_t *)g_main, parg, retry_flags);
+      }
+    } else if (result < 0) {
+      retry_flags = flags_used | TEALET_SWITCH_PANIC | TEALET_SWITCH_FORCE;
+      result = tealet_switch_inner((tealet_t *)g_main, parg, retry_flags);
+    }
+  } else {
+    result = tealet_switch_inner(stub, parg, flags_used);
+  }
 
   tealet_unlock_switch(g_main);
   return result;

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1894,25 +1894,25 @@ int tealet_exit(tealet_t *target, void *arg, int flags) {
   int retry_flags;
   int result;
 
-  assert((flags & ~(TEALET_EXIT_DELETE | TEALET_EXIT_DEFER | TEALET_EXIT_FORCE | TEALET_EXIT_PANIC | TEALET_EXIT_NOFAIL)) ==
-         0);
+  assert((flags &
+          ~(TEALET_EXIT_DELETE | TEALET_EXIT_DEFER | TEALET_EXIT_FORCE | TEALET_EXIT_PANIC | TEALET_EXIT_NOFAIL)) == 0);
   assert(!((flags & TEALET_EXIT_DEFER) && (flags & TEALET_EXIT_PANIC)));
 
   g_current = g_main->g_current;
   tealet_verify_current_matches_caller(g_current);
-  
+
   tealet_lock_switch(g_main);
-  
+
   if (flags & TEALET_EXIT_DEFER) {
     /* setting up arg and flags for the run() return value */
     /* We temporarily borrow g_flags/g_arg storage on main until the
-    * deferred exit is consummated.
-    */
-   assert(g_main->g_flags == 0);
-   g_main->g_arg = arg;
-   g_main->g_flags = flags;
-   tealet_unlock_switch(g_main);
-   return 0; /* deferred exit, we are done here */
+     * deferred exit is consummated.
+     */
+    assert(g_main->g_flags == 0);
+    g_main->g_arg = arg;
+    g_main->g_flags = flags;
+    tealet_unlock_switch(g_main);
+    return 0; /* deferred exit, we are done here */
   }
   if (g_main->g_flags & TEALET_EXIT_DEFER) {
     /* Called second time (e.g. from return of run())

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1819,8 +1819,7 @@ int tealet_switch(tealet_t *stub, void **parg, int flags) {
   int result;
   tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
 
-  if ((flags & ~(TEALET_SWITCH_FORCE | TEALET_SWITCH_PANIC | TEALET_SWITCH_NOFAIL)) != 0)
-    return TEALET_ERR_INVAL;
+  assert((flags & ~(TEALET_SWITCH_FORCE | TEALET_SWITCH_PANIC | TEALET_SWITCH_NOFAIL)) == 0);
 
   g_current = g_main->g_current;
   tealet_verify_current_matches_caller(g_current);
@@ -1832,7 +1831,7 @@ int tealet_switch(tealet_t *stub, void **parg, int flags) {
     retry_flags = flags_used | TEALET_SWITCH_FORCE;
 
     result = tealet_switch_inner(stub, parg, retry_flags);
-    if (result < 0 && result != TEALET_ERR_PANIC) {
+    if (result == TEALET_ERR_MEM || result == TEALET_ERR_DEFUNCT) {
       retry_flags = flags_used | TEALET_SWITCH_PANIC | TEALET_SWITCH_FORCE;
       result = tealet_switch_inner((tealet_t *)g_main, parg, retry_flags);
     }
@@ -1875,6 +1874,8 @@ static int tealet_exit_inner(tealet_t *target, void *arg, int flags) {
   g_target->stack_far = stack_far;
   g_current->stack = NULL;
   g_current->flags &= ~(TEALET_TFLAGS_EXITING | TEALET_TFLAGS_AUTODELETE | TEALET_TFLAGS_EXITFORCE);
+  /* verify that we don't get the switch-back code PANIC */
+  assert(result != TEALET_ERR_PANIC); /* panic should be handled by caller if requested */
   return result;
 }
 
@@ -1929,16 +1930,16 @@ int tealet_exit(tealet_t *target, void *arg, int flags) {
     retry_flags = flags_used | TEALET_EXIT_FORCE;
 
     result = tealet_exit_inner(target, arg, retry_flags);
-    if (result < 0) {
+    if (result == TEALET_ERR_MEM || result == TEALET_ERR_DEFUNCT) {
       retry_flags = flags_used | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
       result = tealet_exit_inner((tealet_t *)g_main, arg, retry_flags);
     }
   } else {
     result = tealet_exit_inner(target, arg, flags_used);
-    assert(result < 0);
   }
 
   tealet_unlock_switch(g_main);
+  assert(result < 0);
   return result;
 }
 

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1367,7 +1367,6 @@ static void tealet_unlock_switch(tealet_main_t *g_main) {
 static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet_sub_t *g_target, tealet_run_t run,
                               void **parg, void *stack_far) {
   int result;
-  int fallback_flags;
   tealet_sub_t *g_exit_target;
   int exit_flags;
   void *exit_arg;
@@ -1440,13 +1439,6 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
     }
 
     result = tealet_exit((tealet_t *)g_exit_target, exit_arg, exit_flags | TEALET_EXIT_NOFAIL);
-    if (result < 0) {
-      /* Preserve implicit-return robustness: if requested transfer still
-       * fails (for example invalid target), panic+force to main.
-       */
-      fallback_flags = (exit_flags & ~TEALET_EXIT_NOFAIL) | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
-      result = tealet_exit((tealet_t *)g_main, exit_arg, fallback_flags);
-    }
     (void)result;
     assert(!"Implicit return transfer failed");
     abort();
@@ -1822,16 +1814,12 @@ static int tealet_switch_inner(tealet_t *stub, void **parg, int flags) {
 int tealet_switch(tealet_t *stub, void **parg, int flags) {
   tealet_sub_t *g_target = (tealet_sub_t *)stub;
   tealet_sub_t *g_current;
-  int allowed_flags;
   int flags_used;
   int retry_flags;
   int result;
   tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
 
-  allowed_flags = TEALET_SWITCH_FORCE | TEALET_SWITCH_PANIC | TEALET_SWITCH_NOFAIL;
-  assert((flags & ~allowed_flags) == 0);
-  if ((flags & ~allowed_flags) != 0)
-    return TEALET_ERR_INVAL;
+  assert((flags & ~(TEALET_SWITCH_FORCE | TEALET_SWITCH_PANIC | TEALET_SWITCH_NOFAIL)) == 0);
 
   g_current = g_main->g_current;
   tealet_verify_current_matches_caller(g_current);
@@ -1903,18 +1891,13 @@ int tealet_exit(tealet_t *target, void *arg, int flags) {
   tealet_sub_t *g_target = (tealet_sub_t *)target;
   tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
   tealet_sub_t *g_current;
-  int allowed_flags;
   int flags_used;
   int retry_flags;
   int result;
 
-  allowed_flags = TEALET_EXIT_DELETE | TEALET_EXIT_DEFER | TEALET_EXIT_FORCE | TEALET_EXIT_PANIC | TEALET_EXIT_NOFAIL;
-  assert((flags & ~allowed_flags) == 0);
+  assert((flags &
+          ~(TEALET_EXIT_DELETE | TEALET_EXIT_DEFER | TEALET_EXIT_FORCE | TEALET_EXIT_PANIC | TEALET_EXIT_NOFAIL)) == 0);
   assert(!((flags & TEALET_EXIT_DEFER) && (flags & TEALET_EXIT_PANIC)));
-  if ((flags & ~allowed_flags) != 0)
-    return TEALET_ERR_INVAL;
-  if ((flags & TEALET_EXIT_DEFER) && (flags & TEALET_EXIT_PANIC))
-    return TEALET_ERR_INVAL;
 
   g_current = g_main->g_current;
   tealet_verify_current_matches_caller(g_current);

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -371,7 +371,9 @@ int tealet_fork(tealet_t *tealet, tealet_t **pother, void **parg, int flags);
  * #TEALET_ERR_PANIC on its resumed switch return path.
  *
  * #TEALET_SWITCH_NOFAIL applies retry/fallback policy: first attempt with
- * FORCE and panic+force fallback to main on remaining failures.
+ * FORCE, then panic+force fallback to main only on #TEALET_ERR_MEM/
+ * #TEALET_ERR_DEFUNCT. Other errors are returned unchanged.
+ * Unknown switch flag bits are API misuse and asserted in debug builds.
  *
  * @warning Do not pass stack-allocated cross-tealet payloads through @p parg.
  */
@@ -409,16 +411,15 @@ int tealet_switch(tealet_t *target, void **parg, int flags);
  *
  * #TEALET_EXIT_PANIC requests panic delivery to the receiving tealet as
  * #TEALET_ERR_PANIC on its resumed switch return path. It is invalid with
- * #TEALET_EXIT_DEFER.
+ * #TEALET_EXIT_DEFER (debug builds assert this flag combination).
  *
  * #TEALET_EXIT_NOFAIL enables automatic retry policy:
- * 1) requested target (fail-fast),
- * 2) requested target with #TEALET_EXIT_FORCE after #TEALET_ERR_MEM,
- * 3) panic+force fallback to main when retries still cannot complete.
+ * 1) requested target with #TEALET_EXIT_FORCE,
+ * 2) panic+force fallback to main only on #TEALET_ERR_MEM/
+ *    #TEALET_ERR_DEFUNCT. Other errors are returned unchanged.
  *
  * `return p;` from run() uses an implicit policy rooted in
- * `tealet_exit(p, NULL, TEALET_EXIT_DELETE)`, with retries for memory/defunct
- * failures and a panic+force fallback to main.
+ * `tealet_exit(p, NULL, TEALET_EXIT_DEFAULT | TEALET_EXIT_NOFAIL)`.
  */
 TEALET_API
 int tealet_exit(tealet_t *target, void *arg, int flags);

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -386,13 +386,15 @@ int tealet_switch(tealet_t *target, void **parg, int flags);
 #define TEALET_EXIT_DEFER 2   /* Defer exit to return statement */
 #define TEALET_EXIT_FORCE 4   /* Force exit switch despite save-time memory failures */
 #define TEALET_EXIT_PANIC 8   /* Mark the receiving tealet as panic-resumed */
+#define TEALET_EXIT_NOFAIL 16 /* Retry with FORCE and panic-to-main fallback */
 
 /**
  * @brief Exit current tealet and transfer control to @p target.
  * @param target Requested target tealet.
  * @param arg Optional argument to deliver to @p target.
  * @param flags Exit behavior bits: #TEALET_EXIT_DEFAULT, #TEALET_EXIT_DELETE,
- * #TEALET_EXIT_DEFER, #TEALET_EXIT_FORCE, #TEALET_EXIT_PANIC.
+ * #TEALET_EXIT_DEFER, #TEALET_EXIT_FORCE, #TEALET_EXIT_PANIC,
+ * #TEALET_EXIT_NOFAIL.
  * @return 0 only for deferred setup path; otherwise returns a negative error code if transfer cannot start.
  *
  * Without #TEALET_EXIT_FORCE, memory pressure while saving state returns #TEALET_ERR_MEM.
@@ -404,6 +406,11 @@ int tealet_switch(tealet_t *target, void **parg, int flags);
  * #TEALET_EXIT_PANIC requests panic delivery to the receiving tealet as
  * #TEALET_ERR_PANIC on its resumed switch return path. It is invalid with
  * #TEALET_EXIT_DEFER.
+ *
+ * #TEALET_EXIT_NOFAIL enables automatic retry policy:
+ * 1) requested target (fail-fast),
+ * 2) requested target with #TEALET_EXIT_FORCE after #TEALET_ERR_MEM,
+ * 3) panic+force fallback to main when retries still cannot complete.
  *
  * `return p;` from run() uses an implicit policy rooted in
  * `tealet_exit(p, NULL, TEALET_EXIT_DELETE)`, with retries for memory/defunct

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -373,7 +373,8 @@ int tealet_fork(tealet_t *tealet, tealet_t **pother, void **parg, int flags);
  * #TEALET_SWITCH_NOFAIL applies retry/fallback policy: first attempt with
  * FORCE, then panic+force fallback to main only on #TEALET_ERR_MEM/
  * #TEALET_ERR_DEFUNCT. Other errors are returned unchanged.
- * Unknown switch flag bits are API misuse and asserted in debug builds.
+ * Unknown switch flag bits return #TEALET_ERR_INVAL and are also asserted in
+ * debug builds.
  *
  * @warning Do not pass stack-allocated cross-tealet payloads through @p parg.
  */
@@ -411,7 +412,8 @@ int tealet_switch(tealet_t *target, void **parg, int flags);
  *
  * #TEALET_EXIT_PANIC requests panic delivery to the receiving tealet as
  * #TEALET_ERR_PANIC on its resumed switch return path. It is invalid with
- * #TEALET_EXIT_DEFER (debug builds assert this flag combination).
+ * #TEALET_EXIT_DEFER and returns #TEALET_ERR_INVAL (also asserted in debug
+ * builds).
  *
  * #TEALET_EXIT_NOFAIL enables automatic retry policy:
  * 1) requested target with #TEALET_EXIT_FORCE,
@@ -419,7 +421,9 @@ int tealet_switch(tealet_t *target, void **parg, int flags);
  *    #TEALET_ERR_DEFUNCT. Other errors are returned unchanged.
  *
  * `return p;` from run() uses an implicit policy rooted in
- * `tealet_exit(p, NULL, TEALET_EXIT_DEFAULT | TEALET_EXIT_NOFAIL)`.
+ * `tealet_exit(p, NULL, TEALET_EXIT_DELETE | TEALET_EXIT_NOFAIL)`.
+ * If that transfer still fails, implicit return retries with panic+force to
+ * main.
  */
 TEALET_API
 int tealet_exit(tealet_t *target, void *arg, int flags);

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -373,8 +373,6 @@ int tealet_fork(tealet_t *tealet, tealet_t **pother, void **parg, int flags);
  * #TEALET_SWITCH_NOFAIL applies retry/fallback policy: first attempt with
  * FORCE, then panic+force fallback to main only on #TEALET_ERR_MEM/
  * #TEALET_ERR_DEFUNCT. Other errors are returned unchanged.
- * Unknown switch flag bits return #TEALET_ERR_INVAL and are also asserted in
- * debug builds.
  *
  * @warning Do not pass stack-allocated cross-tealet payloads through @p parg.
  */
@@ -412,8 +410,7 @@ int tealet_switch(tealet_t *target, void **parg, int flags);
  *
  * #TEALET_EXIT_PANIC requests panic delivery to the receiving tealet as
  * #TEALET_ERR_PANIC on its resumed switch return path. It is invalid with
- * #TEALET_EXIT_DEFER and returns #TEALET_ERR_INVAL (also asserted in debug
- * builds).
+ * #TEALET_EXIT_DEFER (debug builds assert this flag combination).
  *
  * #TEALET_EXIT_NOFAIL enables automatic retry policy:
  * 1) requested target with #TEALET_EXIT_FORCE,
@@ -422,8 +419,6 @@ int tealet_switch(tealet_t *target, void **parg, int flags);
  *
  * `return p;` from run() uses an implicit policy rooted in
  * `tealet_exit(p, NULL, TEALET_EXIT_DELETE | TEALET_EXIT_NOFAIL)`.
- * If that transfer still fails, implicit return retries with panic+force to
- * main.
  */
 TEALET_API
 int tealet_exit(tealet_t *target, void *arg, int flags);

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -355,7 +355,7 @@ int tealet_fork(tealet_t *tealet, tealet_t **pother, void **parg, int flags);
  * @param target Tealet to switch to; must share the same main tealet and thread.
  * @param parg In/out argument pointer passed across switches; may be NULL.
  * @param flags Switch behavior bits: #TEALET_SWITCH_DEFAULT, #TEALET_SWITCH_FORCE,
- * #TEALET_SWITCH_PANIC.
+ * #TEALET_SWITCH_PANIC, #TEALET_SWITCH_NOFAIL.
  * @retval 0 Success.
  * @retval TEALET_ERR_MEM Save/restore failed due to memory pressure.
  * @retval TEALET_ERR_DEFUNCT Target tealet/stack is defunct.
@@ -370,6 +370,10 @@ int tealet_fork(tealet_t *tealet, tealet_t **pother, void **parg, int flags);
  * #TEALET_SWITCH_PANIC requests panic delivery to the receiving tealet as
  * #TEALET_ERR_PANIC on its resumed switch return path.
  *
+ * #TEALET_SWITCH_NOFAIL applies retry/fallback policy: first attempt with
+ * caller flags, retry with FORCE on #TEALET_ERR_MEM, and on remaining failures
+ * panic+force fallback to main.
+ *
  * @warning Do not pass stack-allocated cross-tealet payloads through @p parg.
  */
 TEALET_API
@@ -379,6 +383,7 @@ int tealet_switch(tealet_t *target, void **parg, int flags);
 #define TEALET_SWITCH_DEFAULT 0 /* default switch behavior */
 #define TEALET_SWITCH_FORCE 4   /* force switch despite save-time memory failures */
 #define TEALET_SWITCH_PANIC 8   /* mark the receiving tealet as panic-resumed */
+#define TEALET_SWITCH_NOFAIL 16 /* retry with FORCE and panic-to-main fallback */
 
 /* Exit flags */
 #define TEALET_EXIT_DEFAULT 0 /* Don't auto-delete */

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -371,8 +371,7 @@ int tealet_fork(tealet_t *tealet, tealet_t **pother, void **parg, int flags);
  * #TEALET_ERR_PANIC on its resumed switch return path.
  *
  * #TEALET_SWITCH_NOFAIL applies retry/fallback policy: first attempt with
- * caller flags, retry with FORCE on #TEALET_ERR_MEM, and on remaining failures
- * panic+force fallback to main.
+ * FORCE and panic+force fallback to main on remaining failures.
  *
  * @warning Do not pass stack-allocated cross-tealet payloads through @p parg.
  */

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -560,7 +560,7 @@ static tealet_t *test_lock_transition_run(tealet_t *current, void *arg) {
   lock_snapshot_take(&g_lock_exit_before);
   g_lock_phase = LOCK_PHASE_DONE;
   tealet_exit(g_main, NULL, TEALET_EXIT_DELETE);
-  assert(0);
+  abort();
   return NULL;
 }
 
@@ -599,7 +599,7 @@ static tealet_t *test_lock_transition_stub_run(tealet_t *current, void *arg) {
   lock_snapshot_take(&g_lock_exit_before);
   g_lock_phase = LOCK_PHASE_DONE;
   tealet_exit(g_main, NULL, TEALET_EXIT_DELETE);
-  assert(0);
+  abort();
   return NULL;
 }
 
@@ -656,7 +656,7 @@ void test_lock_transitions_fork(void) {
   assert(result == 0);
   tealet_test_lock_assert_unheld(&g_lock_state);
   tealet_exit(other, NULL, 0);
-  assert(0);
+  abort();
 }
 
 void test_simple_create(void) {
@@ -759,7 +759,7 @@ tealet_t *test_exit_run(tealet_t *t1, void *arg) {
   assert(t1 != g_main);
   status += 1;
   result = tealet_exit(g_main, NULL, (int)(intptr_t)arg);
-  assert(0);
+  abort();
   assert(result == 0);
   return (tealet_t *)-1;
 }
@@ -1199,7 +1199,7 @@ tealet_t *mem_error_tealet(tealet_t *t1, void *arg) {
   res = tealet_switch(peer, &myarg, TEALET_SWITCH_DEFAULT);
   assert(res == TEALET_ERR_MEM);
   tealet_exit(peer, myarg, TEALET_EXIT_DELETE);
-  assert(0); // never runs
+  abort(); // never runs
   return NULL;
 }
 
@@ -1225,7 +1225,7 @@ static tealet_t *oom_force_to_main_run(tealet_t *current, void *arg) {
 
   /* FORCE should continue by defuncting current and transferring out. */
   result = tealet_switch(current->main, NULL, TEALET_SWITCH_FORCE);
-  assert(0);
+  abort();
   assert(result == 0);
   return NULL;
 }
@@ -1294,7 +1294,7 @@ static tealet_t *oom_force_peer_to_main_panic_run(tealet_t *current, void *arg) 
   /* Clear allocator fault so this switch-out can complete. */
   talloc_fail = 0;
   result = tealet_switch(current->main, NULL, TEALET_SWITCH_PANIC);
-  assert(0);
+  abort();
   assert(result == TEALET_ERR_PANIC);
   return NULL;
 }
@@ -1307,7 +1307,7 @@ static tealet_t *oom_force_to_peer_run(tealet_t *current, void *arg) {
 
   talloc_fail = 1;
   result = tealet_switch(oom_w2, NULL, TEALET_SWITCH_FORCE);
-  assert(0);
+  abort();
   assert(result == 0);
   (void)current;
   return NULL;
@@ -1351,7 +1351,7 @@ static tealet_t *switch_nofail_mem_run(tealet_t *current, void *arg) {
   /* Purpose: NOFAIL should retry with FORCE and transfer to main under OOM. */
   talloc_fail = 1;
   tealet_switch(current->main, NULL, TEALET_SWITCH_NOFAIL);
-  assert(0);
+  abort();
   return NULL;
 }
 
@@ -1378,7 +1378,7 @@ static tealet_t *switch_nofail_defunct_target_run(tealet_t *current, void *arg) 
   tealet_t *target = (tealet_t *)arg;
 
   tealet_switch(target, NULL, TEALET_SWITCH_NOFAIL);
-  assert(0);
+  abort();
   (void)current;
   return NULL;
 }
@@ -1418,7 +1418,7 @@ static tealet_t *exit_nofail_mem_run(tealet_t *current, void *arg) {
   /* Purpose: NOFAIL should retry with FORCE and transfer to main under OOM. */
   talloc_fail = 1;
   tealet_exit(current->main, NULL, TEALET_EXIT_NOFAIL);
-  assert(0);
+  abort();
   return NULL;
 }
 
@@ -1445,7 +1445,7 @@ static tealet_t *exit_nofail_defunct_target_run(tealet_t *current, void *arg) {
   tealet_t *target = (tealet_t *)arg;
 
   tealet_exit(target, NULL, TEALET_EXIT_NOFAIL);
-  assert(0);
+  abort();
   (void)current;
   return NULL;
 }
@@ -1487,7 +1487,7 @@ static tealet_t *test_exit_self_invalid_run(tealet_t *current, void *arg) {
   assert(result == TEALET_ERR_INVAL);
 
   tealet_exit(current->main, NULL, TEALET_EXIT_DELETE);
-  assert(0);
+  abort();
   return NULL;
 }
 
@@ -1517,7 +1517,7 @@ static tealet_t *test_exit_defunct_fail_run(tealet_t *current, void *arg) {
   assert(result == TEALET_ERR_DEFUNCT);
 
   tealet_exit(current->main, NULL, TEALET_EXIT_DELETE);
-  assert(0);
+  abort();
   return NULL;
 }
 
@@ -1552,7 +1552,7 @@ static tealet_t *test_explicit_panic_exit_run(tealet_t *current, void *arg) {
 
   assert(current != g_main);
   tealet_exit(target, NULL, TEALET_EXIT_DELETE | TEALET_EXIT_PANIC);
-  assert(0);
+  abort();
   return NULL;
 }
 
@@ -1627,7 +1627,7 @@ static tealet_t *test_invalid_caller_check_child_run(tealet_t *current, void *ar
   assert(result == 0);
 
   tealet_exit(g_main, NULL, TEALET_EXIT_DELETE);
-  assert(0);
+  abort();
   return NULL;
 }
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -1345,6 +1345,73 @@ void test_oom_force_peer_then_panic_main(void) {
   fini_test();
 }
 
+static tealet_t *exit_nofail_mem_run(tealet_t *current, void *arg) {
+  (void)arg;
+
+  /* Purpose: NOFAIL should retry with FORCE and transfer to main under OOM. */
+  talloc_fail = 1;
+  tealet_exit(current->main, NULL, TEALET_EXIT_NOFAIL);
+  assert(0);
+  return NULL;
+}
+
+void test_exit_nofail_retries_force(void) {
+  tealet_t *worker;
+  int result;
+
+  init_test_extra(NULL, 0);
+
+  worker = NULL;
+  assert(tealet_spawn(g_main, &worker, exit_nofail_mem_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(worker != NULL);
+
+  result = tealet_switch(worker, NULL, TEALET_SWITCH_DEFAULT);
+  assert(result == 0);
+
+  talloc_fail = 0;
+  assert(tealet_status(worker) != TEALET_STATUS_ACTIVE);
+  tealet_delete(worker);
+  fini_test();
+}
+
+static tealet_t *exit_nofail_defunct_target_run(tealet_t *current, void *arg) {
+  tealet_t *target = (tealet_t *)arg;
+
+  tealet_exit(target, NULL, TEALET_EXIT_NOFAIL);
+  assert(0);
+  (void)current;
+  return NULL;
+}
+
+void test_exit_nofail_defunct_target_panics_main(void) {
+  tealet_t *victim;
+  tealet_t *exiter;
+  void *arg;
+  int result;
+
+  init_test_extra(NULL, 0);
+
+  victim = NULL;
+  assert(tealet_spawn(g_main, &victim, oom_force_to_main_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(victim != NULL);
+
+  result = tealet_switch(victim, NULL, TEALET_SWITCH_DEFAULT);
+  assert(result == 0);
+  talloc_fail = 0;
+  assert(tealet_status(victim) == TEALET_STATUS_DEFUNCT);
+
+  exiter = NULL;
+  assert(tealet_spawn(g_main, &exiter, exit_nofail_defunct_target_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(exiter != NULL);
+  arg = (void *)victim;
+  result = tealet_switch(exiter, &arg, TEALET_SWITCH_DEFAULT);
+  assert(result == TEALET_ERR_PANIC);
+
+  tealet_delete(exiter);
+  tealet_delete(victim);
+  fini_test();
+}
+
 static tealet_t *test_exit_self_invalid_run(tealet_t *current, void *arg) {
   int result;
   (void)arg;
@@ -1545,6 +1612,8 @@ static test_entry_t test_list[] = {
     {"test_oom_force_marks_source_defunct", test_oom_force_marks_source_defunct},
     {"test_oom_force_main_not_defunct", test_oom_force_main_not_defunct},
     {"test_oom_force_peer_then_panic_main", test_oom_force_peer_then_panic_main},
+    {"test_exit_nofail_retries_force", test_exit_nofail_retries_force},
+    {"test_exit_nofail_defunct_target_panics_main", test_exit_nofail_defunct_target_panics_main},
     {"test_exit_self_invalid", test_exit_self_invalid},
 #if TEALET_WITH_TESTING
     {"test_exit_defunct_target_returns_error", test_exit_defunct_target_returns_error},

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -1345,6 +1345,73 @@ void test_oom_force_peer_then_panic_main(void) {
   fini_test();
 }
 
+static tealet_t *switch_nofail_mem_run(tealet_t *current, void *arg) {
+  (void)arg;
+
+  /* Purpose: NOFAIL should retry with FORCE and transfer to main under OOM. */
+  talloc_fail = 1;
+  tealet_switch(current->main, NULL, TEALET_SWITCH_NOFAIL);
+  assert(0);
+  return NULL;
+}
+
+void test_switch_nofail_retries_force(void) {
+  tealet_t *worker;
+  int result;
+
+  init_test_extra(NULL, 0);
+
+  worker = NULL;
+  assert(tealet_spawn(g_main, &worker, switch_nofail_mem_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(worker != NULL);
+
+  result = tealet_switch(worker, NULL, TEALET_SWITCH_DEFAULT);
+  assert(result == 0);
+
+  talloc_fail = 0;
+  assert(tealet_status(worker) == TEALET_STATUS_DEFUNCT);
+  tealet_delete(worker);
+  fini_test();
+}
+
+static tealet_t *switch_nofail_defunct_target_run(tealet_t *current, void *arg) {
+  tealet_t *target = (tealet_t *)arg;
+
+  tealet_switch(target, NULL, TEALET_SWITCH_NOFAIL);
+  assert(0);
+  (void)current;
+  return NULL;
+}
+
+void test_switch_nofail_defunct_target_panics_main(void) {
+  tealet_t *victim;
+  tealet_t *switcher;
+  void *arg;
+  int result;
+
+  init_test_extra(NULL, 0);
+
+  victim = NULL;
+  assert(tealet_spawn(g_main, &victim, oom_force_to_main_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(victim != NULL);
+
+  result = tealet_switch(victim, NULL, TEALET_SWITCH_DEFAULT);
+  assert(result == 0);
+  talloc_fail = 0;
+  assert(tealet_status(victim) == TEALET_STATUS_DEFUNCT);
+
+  switcher = NULL;
+  assert(tealet_spawn(g_main, &switcher, switch_nofail_defunct_target_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(switcher != NULL);
+  arg = (void *)victim;
+  result = tealet_switch(switcher, &arg, TEALET_SWITCH_DEFAULT);
+  assert(result == TEALET_ERR_PANIC);
+
+  tealet_delete(switcher);
+  tealet_delete(victim);
+  fini_test();
+}
+
 static tealet_t *exit_nofail_mem_run(tealet_t *current, void *arg) {
   (void)arg;
 
@@ -1612,6 +1679,8 @@ static test_entry_t test_list[] = {
     {"test_oom_force_marks_source_defunct", test_oom_force_marks_source_defunct},
     {"test_oom_force_main_not_defunct", test_oom_force_main_not_defunct},
     {"test_oom_force_peer_then_panic_main", test_oom_force_peer_then_panic_main},
+    {"test_switch_nofail_retries_force", test_switch_nofail_retries_force},
+    {"test_switch_nofail_defunct_target_panics_main", test_switch_nofail_defunct_target_panics_main},
     {"test_exit_nofail_retries_force", test_exit_nofail_retries_force},
     {"test_exit_nofail_defunct_target_panics_main", test_exit_nofail_defunct_target_panics_main},
     {"test_exit_self_invalid", test_exit_self_invalid},


### PR DESCRIPTION
## Summary
- add TEALET_EXIT_NOFAIL robust fallback behavior
- add TEALET_SWITCH_NOFAIL with switch-side fallback policy
- simplify NOFAIL policy to force-first attempts
- preserve PANIC as legitimate switch-back signal (no NOFAIL retry on PANIC)
- refactor switch flow with inner helper to keep lock scope clean
- add regression tests for NOFAIL switch/exit fallback paths
- update API docs and cross-reference NOFAIL policy details

## Validation
- make test
