### PR TITLE
Unify transfer flags under TEALET_XFER_* and refactor transfer internals

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,7 +76,7 @@ tealet_finalize(main);
 tealet_t *g = tealet_new(main);
 tealet_run(g, run_func, NULL, NULL, TEALET_RUN_DEFAULT);
 void *arg = my_data;
-tealet_switch(g, &arg, TEALET_SWITCH_DEFAULT);
+tealet_switch(g, &arg, TEALET_XFER_DEFAULT);
 
 // Pattern 2: Create and switch atomically
 tealet_t *g = tealet_new(main);
@@ -96,7 +96,7 @@ tealet_t *my_run(tealet_t *current, void *arg) {
 ```c
 // In run function:
 tealet_exit(target, arg, TEALET_EXIT_DELETE);  // Delete current tealet
-tealet_exit(target, arg, TEALET_EXIT_DEFAULT);     // Keep tealet alive
+tealet_exit(target, arg, TEALET_XFER_DEFAULT);     // Keep tealet alive
 tealet_exit(target, arg, TEALET_EXIT_DEFER);    // Defer to return statement
 ```
 
@@ -108,7 +108,7 @@ tealet_exit(target, arg, TEALET_EXIT_DEFER);    // Defer to return statement
 - Types: `*_t` suffix (e.g., `tealet_t`, `tealet_run_t`)
 - Error codes: Negative integers (`TEALET_ERR_*`)
 - Status codes: `TEALET_STATUS_*`
-- Flags: `TEALET_EXIT_*`, `TEALET_SWITCH_*`, `TEALET_RUN_*`
+- Flags: `TEALET_XFER_*`, `TEALET_EXIT_*`, `TEALET_RUN_*`
 
 ### C Standards
 - Written in C89/C90 compatible style

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `TEALET_XFER_*` occupies the low 8-bit transfer flag space; exit-only flags
     begin at `0x100` to reserve headroom for future transfer-flag growth.
 
+- **Build now tracks generated header dependencies automatically**
+  - Make rules now emit and include compiler-generated dependency files for C
+    objects.
+  - Header edits now trigger the correct object rebuilds without requiring a
+    manual clean step.
+
 ### Removed
 - **Legacy creation API surface removed from core**
   - Removed core `tealet_create()` and the old create-and-start `tealet_new(...)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `tealet_switch()` accepts only `TEALET_XFER_*`.
   - `tealet_exit()` accepts `TEALET_XFER_*` plus exit-only
     `TEALET_EXIT_DELETE` / `TEALET_EXIT_DEFER`.
+  - `TEALET_XFER_*` occupies the low 8-bit transfer flag space; exit-only flags
+    begin at `0x100` to reserve headroom for future transfer-flag growth.
 
 ### Removed
 - **Legacy creation API surface removed from core**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     switch) are returned unchanged.
 
 ### Changed
+- **Transfer internals now use one-shot signaling flags with explicit consumption points**
+  - Renamed the internal transient per-tealet force bit from `EXITFORCE` to
+    `SAVEFORCE` to reflect that it applies to save behavior generally, not only
+    exit flows.
+  - Clarified internal ownership/lifecycle: transfer prep sets one-shot signals
+    (`SAVEFORCE`, `PANIC`) before the handoff, and low-level transfer helpers
+    consume and clear them during the same operation.
+
+- **Switch/exit transfer paths are now factored around shared kinship**
+  - Refactored `tealet_switch()` and `tealet_exit()` to leverage a shared
+    internal transfer helper (`tealet_xfer_inner`) for common transfer
+    mechanics, while preserving each API's mode-specific behavior.
+  - Kept mode-specific semantics explicit (for example exit-mode invariants and
+    retry policy orchestration) while reducing duplicate transfer plumbing.
+
 - **Run-return lifecycle now keeps tealets alive by default**
   - Returning from a tealet run function now follows `TEALET_EXIT_DEFAULT`
     semantics (tealet remains allocated) instead of implicit delete.
@@ -38,11 +53,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `tealet_fork()` now uses `TEALET_RUN_DEFAULT` / `TEALET_RUN_SWITCH`
     mode flags.
 
-- **Transfer flags are unified across switch and exit**
-  - Shared transfer behavior now uses `TEALET_XFER_*` flags.
-  - `tealet_switch()` accepts only `TEALET_XFER_*`.
-  - `tealet_exit()` accepts `TEALET_XFER_*` plus exit-only
-    `TEALET_EXIT_DELETE` / `TEALET_EXIT_DEFER`.
+- **Public transfer flags were renamed to `TEALET_XFER_*`**
+  - User-facing switch/exit transfer behavior now uses shared
+    `TEALET_XFER_*` names.
+  - `tealet_switch()` now uses:
+    - `TEALET_XFER_FORCE` (was `TEALET_SWITCH_FORCE`)
+    - `TEALET_XFER_PANIC` (was `TEALET_SWITCH_PANIC`)
+    - `TEALET_XFER_NOFAIL` (was `TEALET_SWITCH_NOFAIL`)
+  - `tealet_exit()` now uses:
+    - `TEALET_XFER_FORCE` (was `TEALET_EXIT_FORCE`)
+    - `TEALET_XFER_PANIC` (was `TEALET_EXIT_PANIC`)
+    - `TEALET_XFER_NOFAIL` (was `TEALET_EXIT_NOFAIL`)
+    - plus exit-only `TEALET_EXIT_DELETE` / `TEALET_EXIT_DEFER`.
   - `TEALET_XFER_*` occupies the low 8-bit transfer flag space; exit-only flags
     begin at `0x100` to reserve headroom for future transfer-flag growth.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **NOFAIL transfer policies for both exit and switch APIs**
-  - Added `TEALET_EXIT_NOFAIL` and `TEALET_SWITCH_NOFAIL` to provide a
+  - Added `TEALET_XFER_NOFAIL` to provide a
     robustness-oriented transfer mode for callers that prioritize forward
     progress under memory pressure/defunct-target conditions.
   - NOFAIL attempts the requested transfer with FORCE first.
@@ -38,12 +38,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `tealet_fork()` now uses `TEALET_RUN_DEFAULT` / `TEALET_RUN_SWITCH`
     mode flags.
 
+- **Transfer flags are unified across switch and exit**
+  - Shared transfer behavior now uses `TEALET_XFER_*` flags.
+  - `tealet_switch()` accepts only `TEALET_XFER_*`.
+  - `tealet_exit()` accepts `TEALET_XFER_*` plus exit-only
+    `TEALET_EXIT_DELETE` / `TEALET_EXIT_DEFER`.
+
 ### Removed
 - **Legacy creation API surface removed from core**
   - Removed core `tealet_create()` and the old create-and-start `tealet_new(...)`
     out-parameter signature.
   - Removed legacy `TEALET_FORK_DEFAULT` / `TEALET_FORK_SWITCH` flags in favor
     of `TEALET_RUN_*`.
+
+- **Separate switch/exit transfer-flag names removed**
+  - Removed `TEALET_SWITCH_DEFAULT` / `TEALET_SWITCH_FORCE` /
+    `TEALET_SWITCH_PANIC` / `TEALET_SWITCH_NOFAIL`.
+  - Removed `TEALET_EXIT_DEFAULT` / `TEALET_EXIT_FORCE` /
+    `TEALET_EXIT_PANIC` / `TEALET_EXIT_NOFAIL`.
 
 ### Documentation
 - Updated `README.md`, `docs/GETTING_STARTED.md`, `docs/API.md`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     retry policy orchestration) while reducing duplicate transfer plumbing.
 
 - **Run-return lifecycle now keeps tealets alive by default**
-  - Returning from a tealet run function now follows `TEALET_EXIT_DEFAULT`
-    semantics (tealet remains allocated) instead of implicit delete.
+  - Returning from a tealet run function now follows default non-delete exit
+    semantics (equivalent to `TEALET_XFER_DEFAULT` transfer behavior for
+    `tealet_exit()`), so the tealet remains allocated instead of being
+    implicitly deleted.
   - Automatic deletion remains available via explicit
     `tealet_exit(..., TEALET_EXIT_DELETE)`.
   - Tests and examples were updated to perform explicit `tealet_delete()`

--- a/Makefile
+++ b/Makefile
@@ -224,8 +224,14 @@ tests/test_current.o: tests/test_current.c src/tealet.h
 # Load compiler-generated header dependencies when present.
 -include $(wildcard src/*.d tests/*.d)
 
+tests/setcontext.o: tests/setcontext.c src/tealet.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c -o $@ tests/setcontext.c
+
 bin/test-setcontext: bin tests/setcontext.o bin/libtealet.so
 	$(CC) $(LDFLAGS) $(STATIC_FLAG) -o $@ tests/setcontext.o ${DEBUG} -ltealet
+
+tests/tests.o: tests/tests.c src/tealet.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c -o $@ tests/tests.c
 
 bin/test-static: bin tests/tests.o bin/libtealet.a
 	$(CC) $(LDFLAGS) $(STATIC_FLAG) -o $@ tests/tests.o ${DEBUG} -ltealet

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ CPPFLAGS += -Isrc -Istackman/stackman $(PLATFORMFLAGS) -DTEALET_WITH_STATS=1 \
 	-DTEALET_WITH_STACK_SNAPSHOT=$(TEALET_WITH_STACK_SNAPSHOT) \
 	-DTEALET_WITH_TESTING=$(TEALET_WITH_TESTING)
 CFLAGS += -fPIC -Wall $(PLATFORMFLAGS)
+DEPFLAGS = -MMD -MP
 LDFLAGS += -Lbin $(PLATFORMFLAGS)
 
 # Handle cross-compilation
@@ -58,10 +59,10 @@ coreobj = src/tealet.o #src/switch_S.o src/switch_c.o
 allobj = $(coreobj) src/tealet_extras.o
 
 src/tealet.o: src/tealet.c src/tealet.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ src/tealet.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c -o $@ src/tealet.c
 
 src/tealet_extras.o: src/tealet_extras.c src/tealet_extras.h src/tealet.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ src/tealet_extras.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c -o $@ src/tealet_extras.c
 
 bin:
 	mkdir -p bin
@@ -78,7 +79,7 @@ bin/libtealet.a: bin $(allobj)
 	@rm -rf bin/tmp_ar
 
 clean:
-	rm -f src/*.o tests/*.o *.out *.so
+	rm -f src/*.o src/*.d tests/*.o tests/*.d *.out *.so
 	rm -rf bin/*
 
 .PHONY: abiname
@@ -190,35 +191,38 @@ bin/test-chunks: bin tests/test_chunks.o bin/libtealet.a
 	$(CC) $(LDFLAGS) $(STATIC_FLAG) -o $@ tests/test_chunks.o -ltealet
 
 tests/test_chunks.o: tests/test_chunks.c src/tealet.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ tests/test_chunks.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c -o $@ tests/test_chunks.c
 
 # Stochastic switching test
 bin/test-stochastic: bin tests/test_stochastic.o bin/libtealet.a
 	$(CC) $(LDFLAGS) $(STATIC_FLAG) -o $@ tests/test_stochastic.o -ltealet
 
 tests/test_stochastic.o: tests/test_stochastic.c src/tealet.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ tests/test_stochastic.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c -o $@ tests/test_stochastic.c
 
 # Fork test
 bin/test-fork: bin tests/test_fork.o bin/libtealet.a
 	$(CC) $(LDFLAGS) $(STATIC_FLAG) -o $@ tests/test_fork.o -ltealet
 
 tests/test_fork.o: tests/test_fork.c src/tealet.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ tests/test_fork.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c -o $@ tests/test_fork.c
 
 # Configure API test
 bin/test-config: bin tests/test_config.o bin/libtealet.a
 	$(CC) $(LDFLAGS) $(STATIC_FLAG) -o $@ tests/test_config.o -ltealet
 
 tests/test_config.o: tests/test_config.c src/tealet.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ tests/test_config.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c -o $@ tests/test_config.c
 
 # Current tealet test
 bin/test-current: bin tests/test_current.o bin/libtealet.a
 	$(CC) $(LDFLAGS) $(STATIC_FLAG) -o $@ tests/test_current.o -ltealet
 
 tests/test_current.o: tests/test_current.c src/tealet.h
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ tests/test_current.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c -o $@ tests/test_current.c
+
+# Load compiler-generated header dependencies when present.
+-include $(wildcard src/*.d tests/*.d)
 
 bin/test-setcontext: bin tests/setcontext.o bin/libtealet.so
 	$(CC) $(LDFLAGS) $(STATIC_FLAG) -o $@ tests/setcontext.o ${DEBUG} -ltealet

--- a/docs/API.md
+++ b/docs/API.md
@@ -1364,13 +1364,13 @@ Switch result signaling explicit panic-tagged resume.
 ```c
 /* Transfer flags (shared by tealet_switch() and tealet_exit()) */
 #define TEALET_XFER_DEFAULT 0  /* Default transfer behavior */
-#define TEALET_XFER_FORCE   4  /* Force transfer despite save-time memory failures */
-#define TEALET_XFER_PANIC   8  /* Mark receiving tealet as panic-resumed */
-#define TEALET_XFER_NOFAIL 16  /* Retry with FORCE, then panic+force to main */
+#define TEALET_XFER_FORCE   1  /* Force transfer despite save-time memory failures */
+#define TEALET_XFER_PANIC   2  /* Mark receiving tealet as panic-resumed */
+#define TEALET_XFER_NOFAIL  4  /* Retry with FORCE, then panic+force to main */
 
 /* Exit-only flags */
-#define TEALET_EXIT_DELETE  1  /* Auto-delete on exit; pointers to exiting tealet become invalid */
-#define TEALET_EXIT_DEFER   2  /* Defer exit to return */
+#define TEALET_EXIT_DELETE  256  /* Auto-delete on exit; pointers to exiting tealet become invalid */
+#define TEALET_EXIT_DEFER   512  /* Defer exit to return */
 ```
 
 Used with `tealet_switch()` and `tealet_exit()`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -113,7 +113,7 @@ tealet_t *t = tealet_new(main);
 tealet_run(t, my_run, NULL, NULL, TEALET_RUN_DEFAULT);
 
 void *arg = my_data;
-tealet_switch(t, &arg, TEALET_SWITCH_DEFAULT);
+tealet_switch(t, &arg, TEALET_XFER_DEFAULT);
 ```
 
 **Usage (create and start immediately):**
@@ -191,7 +191,7 @@ tealet_t *my_run(tealet_t *current, void *arg) {
     
     /* Do work, possibly switching to other tealets */
     void *data = process(arg);
-    tealet_switch(current->main, &data, TEALET_SWITCH_DEFAULT);
+    tealet_switch(current->main, &data, TEALET_XFER_DEFAULT);
     
     /* More work */
     
@@ -323,7 +323,7 @@ int main(void) {
         
         /* CRITICAL: Forked tealets MUST use tealet_exit() */
         void *return_value = (void*)0x1234;
-        tealet_exit(other, return_value, TEALET_EXIT_NOFAIL);  /* Switch back to parent */
+        tealet_exit(other, return_value, TEALET_XFER_NOFAIL);  /* Switch back to parent */
         
         /* Should not reach here */
         abort();
@@ -334,7 +334,7 @@ int main(void) {
         
         /* Switch to child with an argument */
         arg = (void*)0x5678;
-        tealet_switch(other, &arg, TEALET_SWITCH_DEFAULT);
+        tealet_switch(other, &arg, TEALET_XFER_DEFAULT);
         printf("Parent: child returned with arg=%p\n", arg);
         
         /* Clean up */
@@ -385,7 +385,7 @@ Suspend current tealet and resume target tealet.
 **Parameters:**
 - `target`: Tealet to switch to
 - `parg`: Pointer to argument pointer (passed to target, updated with return value)
-- `flags`: Switch control flags (`TEALET_SWITCH_DEFAULT`, `TEALET_SWITCH_FORCE`, `TEALET_SWITCH_PANIC`, `TEALET_SWITCH_NOFAIL`)
+- `flags`: Switch control flags (`TEALET_XFER_DEFAULT`, `TEALET_XFER_FORCE`, `TEALET_XFER_PANIC`, `TEALET_XFER_NOFAIL`)
 
 **Returns:** 
 - `0` on success
@@ -394,30 +394,29 @@ Suspend current tealet and resume target tealet.
 - `TEALET_ERR_PANIC` when resumed due to an explicit panic-tagged transfer (`tealet_exit()` or `tealet_switch()` with panic)
 - Negative error code on failure
 
-`TEALET_SWITCH_FORCE` applies the same non-failable save behavior as
-`TEALET_EXIT_FORCE`:
+`TEALET_XFER_FORCE` enables non-failable save behavior:
 - without FORCE, save-time memory failures are returned (`TEALET_ERR_MEM`)
 - with FORCE, save-time memory failures are ignored so the requested transfer can proceed
     by marking affected non-main saved stacks/tealets defunct.
 
-`TEALET_SWITCH_FORCE` can still return `TEALET_ERR_MEM` when the only way to
+`TEALET_XFER_FORCE` can still return `TEALET_ERR_MEM` when the only way to
 continue would require main-stack growth that fails under memory pressure.
 Main is never marked defunct, so this edge case remains a hard memory failure.
 
 This means a successful forced switch can make other tealets become defunct as
 the trade-off for forward progress under memory pressure.
 
-`TEALET_SWITCH_NOFAIL` applies a robust retry/fallback policy: first try the
-requested target with `TEALET_SWITCH_FORCE`, then panic+force fallback to main
+`TEALET_XFER_NOFAIL` applies a robust retry/fallback policy: first try the
+requested target with `TEALET_XFER_FORCE`, then panic+force fallback to main
 for `TEALET_ERR_MEM` / `TEALET_ERR_DEFUNCT` failures.
 See the detailed policy discussion and conceptual retry flow under
-`tealet_exit()` / `TEALET_EXIT_NOFAIL` below; `TEALET_SWITCH_NOFAIL` follows
+`tealet_exit()` / `TEALET_XFER_NOFAIL` below; `TEALET_XFER_NOFAIL` follows
 the same shape with switch flags.
 
-When the requested target is `main`, `TEALET_SWITCH_NOFAIL` is guaranteed to
+When the requested target is `main`, `TEALET_XFER_NOFAIL` is guaranteed to
 succeed (transfer starts), because main is never allowed to become defunct.
 
-`TEALET_SWITCH_NOFAIL` can still return `TEALET_ERR_PANIC`, because panic is a
+`TEALET_XFER_NOFAIL` can still return `TEALET_ERR_PANIC`, because panic is a
 legitimate switch-back signal (not a transfer failure to retry). In typical
 usage, panic-tagged fallbacks target main, so this check is usually needed on
 the main tealet's switch return path.
@@ -425,7 +424,7 @@ the main tealet's switch return path.
 **Usage:**
 ```c
 void *arg = my_data;
-int result = tealet_switch(target, &arg, TEALET_SWITCH_DEFAULT);
+int result = tealet_switch(target, &arg, TEALET_XFER_DEFAULT);
 if (result == 0) {
     /* arg now contains value passed back from target */
 } else {
@@ -445,7 +444,7 @@ tealet_t *ping(tealet_t *current, void *arg) {
     tealet_t *pong = (tealet_t*)arg;
     
     void *data = "ping";
-    tealet_switch(pong, &data, TEALET_SWITCH_DEFAULT);
+    tealet_switch(pong, &data, TEALET_XFER_DEFAULT);
     /* data now contains "pong" */
     
     return current->main;
@@ -453,7 +452,7 @@ tealet_t *ping(tealet_t *current, void *arg) {
 
 tealet_t *pong(tealet_t *current, void *arg) {
     void *data = "pong";
-    tealet_switch(arg, &data, TEALET_SWITCH_DEFAULT);  /* Switch back to ping */
+    tealet_switch(arg, &data, TEALET_XFER_DEFAULT);  /* Switch back to ping */
     return current->main;
 }
 ```
@@ -478,13 +477,13 @@ Exit current tealet and transfer control to target.
 - `flags`: Control flags (see below)
 
 **Flags:**
-- `TEALET_EXIT_DEFAULT` (0): Don't auto-delete, manual cleanup required
+- `TEALET_XFER_DEFAULT` (0): Don't auto-delete, manual cleanup required
 - `TEALET_EXIT_DELETE`: Auto-delete tealet on exit; outstanding pointers to the exiting tealet become invalid after transfer
 - `TEALET_EXIT_DEFER`:  Store flags and argument, return to caller.  Will be used when
   tealet exits later.
-- `TEALET_EXIT_FORCE`: Force the requested transfer despite save-time memory pressure by defuncting affected non-main stacks as needed
-- `TEALET_EXIT_PANIC`: Tag the receiving tealet's resumed switch return as `TEALET_ERR_PANIC`
-- `TEALET_EXIT_NOFAIL`: Apply automatic retries (`FORCE`, then `PANIC|FORCE` to main fallback)
+- `TEALET_XFER_FORCE`: Force the requested transfer despite save-time memory pressure by defuncting affected non-main stacks as needed
+- `TEALET_XFER_PANIC`: Tag the receiving tealet's resumed switch return as `TEALET_ERR_PANIC`
+- `TEALET_XFER_NOFAIL`: Apply automatic retries (`FORCE`, then `PANIC|FORCE` to main fallback)
 
 **Usage:**
 ```c
@@ -492,7 +491,7 @@ tealet_t *my_run(tealet_t *current, void *arg) {
     /* Do work */
     
     /* Exit and delete this tealet */
-    tealet_exit(current->main, &result, TEALET_EXIT_DELETE | TEALET_EXIT_NOFAIL);
+    tealet_exit(current->main, &result, TEALET_EXIT_DELETE | TEALET_XFER_NOFAIL);
     
     /* Never reached */
 }
@@ -521,52 +520,53 @@ This function does not return on successful transfer.
 **Returns:**
 - `0` only when `TEALET_EXIT_DEFER` is used (deferred exit setup succeeds)
 - Negative error code on failure
-    - `TEALET_ERR_MEM` when save/restore cannot complete and `TEALET_EXIT_FORCE` is not set
+    - `TEALET_ERR_MEM` when save/restore cannot complete and `TEALET_XFER_FORCE` is not set
     - `TEALET_ERR_DEFUNCT` when the requested target is defunct
     - `TEALET_ERR_INVAL` for invalid target/state
 
 `tealet_exit()` does not implicitly reroute to another target.
 
-`TEALET_EXIT_FORCE` mirrors `TEALET_SWITCH_FORCE` behavior:
+`TEALET_XFER_FORCE` in `tealet_exit()` follows the same transfer behavior used
+by `tealet_switch()`:
 - without FORCE, save-time memory failures are returned (`TEALET_ERR_MEM`)
 - with FORCE, save-time memory failures are ignored so the requested transfer can proceed
     by marking affected non-main saved stacks/tealets defunct.
 
-`TEALET_EXIT_FORCE` can still return `TEALET_ERR_MEM` when the only way to
+`TEALET_XFER_FORCE` can still return `TEALET_ERR_MEM` when the only way to
 continue would require main-stack growth that fails under memory pressure.
 
-`TEALET_EXIT_NOFAIL` applies the same robust fallback policy used by implicit
+`TEALET_XFER_NOFAIL` applies the same robust fallback policy used by implicit
 run-function return handling:
-- try requested target with `TEALET_EXIT_FORCE`
-- reroute to main with `TEALET_EXIT_PANIC | TEALET_EXIT_FORCE` only on
+- try requested target with `TEALET_XFER_FORCE`
+- reroute to main with `TEALET_XFER_PANIC | TEALET_XFER_FORCE` only on
     `TEALET_ERR_MEM` / `TEALET_ERR_DEFUNCT`
 - return other errors unchanged
 Main is never marked defunct, so this edge case remains a hard memory failure.
 
-When the requested target is `main`, `TEALET_EXIT_NOFAIL` is guaranteed to
+When the requested target is `main`, `TEALET_XFER_NOFAIL` is guaranteed to
 succeed (transfer starts), because main is never allowed to become defunct.
 
 This means a successful forced exit can make other tealets become defunct as
 the trade-off for forward progress under memory pressure.
 
 **Note:** Returning from the run function does not auto-delete by default; it
-uses `TEALET_EXIT_DEFAULT` semantics unless `TEALET_EXIT_DELETE` was requested
+uses `TEALET_XFER_DEFAULT` semantics unless `TEALET_EXIT_DELETE` was requested
 explicitly (for example via deferred exit flags).
 Use `tealet_exit()` when you need explicit control over deletion or want to
 exit from nested calls within the run function.
 
-**Robust retry policy used by `TEALET_EXIT_NOFAIL` (conceptual flow):**
+**Robust retry policy used by `TEALET_XFER_NOFAIL` (conceptual flow):**
 ```c
 /* Conceptual helper: return non-robustness failures unchanged. */
 static int exit_nofail_policy(tealet_t *self, tealet_t *target, void *arg, int base_flags) {
     int r;
 
     /* 1) First attempt: requested target, FORCE enabled. */
-    r = tealet_exit(target, arg, base_flags | TEALET_EXIT_FORCE);
+    r = tealet_exit(target, arg, base_flags | TEALET_XFER_FORCE);
 
     if (r == TEALET_ERR_MEM || r == TEALET_ERR_DEFUNCT) {
         /* 2) Robustness failures: panic+force fallback to main. */
-        (void)tealet_exit(self->main, arg, base_flags | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE);
+        (void)tealet_exit(self->main, arg, base_flags | TEALET_XFER_PANIC | TEALET_XFER_FORCE);
         abort();
     }
 
@@ -578,7 +578,7 @@ static int exit_nofail_policy(tealet_t *self, tealet_t *target, void *arg, int b
 In normal code, prefer the built-in helper policy directly:
 
 ```c
-tealet_exit(target, arg, base_flags | TEALET_EXIT_NOFAIL);
+tealet_exit(target, arg, base_flags | TEALET_XFER_NOFAIL);
 /* Non-returning on success */
 ```
 
@@ -658,7 +658,7 @@ switch (status) {
 ```c
 while (tealet_status(gen) == TEALET_STATUS_ACTIVE) {
     process(value);
-    tealet_switch(gen, &value, TEALET_SWITCH_DEFAULT);  /* Get next value */
+    tealet_switch(gen, &value, TEALET_XFER_DEFAULT);  /* Get next value */
 }
 ```
 
@@ -1028,7 +1028,7 @@ tealet_delete(t);
 
 **When to Use:**
 - Deleting tealets that never ran (`TEALET_STATUS_INITIAL`)
-- Cleaning up tealets kept alive with `TEALET_EXIT_DEFAULT`
+- Cleaning up tealets kept alive with `TEALET_XFER_DEFAULT`
 - Cleaning up tealets that returned normally
 - Manual resource management
 
@@ -1243,10 +1243,10 @@ For `tealet_switch()`:
 - On `TEALET_ERR_MEM`: treat as transient resource failure; free optional resources and either retry later or abort the coroutine workflow cleanly.
 - On `TEALET_ERR_DEFUNCT`: treat target as unusable, inspect status, and delete/replace that tealet.
 - On `TEALET_ERR_PANIC`: treat as explicit panic resume signal from
-    `tealet_exit(..., TEALET_EXIT_PANIC)` or `tealet_switch(..., TEALET_SWITCH_PANIC)`.
+    `tealet_exit(..., TEALET_XFER_PANIC)` or `tealet_switch(..., TEALET_XFER_PANIC)`.
 
-Forced transfer note (`tealet_switch(..., TEALET_SWITCH_FORCE)` and
-`tealet_exit(..., TEALET_EXIT_FORCE)`):
+Forced transfer note (`tealet_switch(..., TEALET_XFER_FORCE)` and
+`tealet_exit(..., TEALET_XFER_FORCE)`):
 - these APIs can succeed while ignoring save-time memory errors
 - in that success path, affected non-main saved stacks/tealets may be marked defunct.
 
@@ -1265,7 +1265,7 @@ For `tealet_exit()` specifically:
 ### Note
 
 `TEALET_ERR_PANIC` is the explicit panic-resume signal produced by
-`tealet_exit(..., TEALET_EXIT_PANIC)` or `tealet_switch(..., TEALET_SWITCH_PANIC)`.
+`tealet_exit(..., TEALET_XFER_PANIC)` or `tealet_switch(..., TEALET_XFER_PANIC)`.
 
 ---
 
@@ -1304,8 +1304,8 @@ if (tealet_run(t, my_run, NULL, NULL, TEALET_RUN_DEFAULT) != 0) {
 Target tealet is defunct (invalid for switching).
 
 **Causes:**
-- Successful forced transfer under memory pressure (`TEALET_SWITCH_FORCE` or
-    `TEALET_EXIT_FORCE`) can ignore save-time memory errors and mark affected
+- Successful forced transfer under memory pressure (`TEALET_XFER_FORCE`)
+    can ignore save-time memory errors and mark affected
     non-main saved stacks/tealets defunct.
 - Saved stack became invalid (for example due to a non-recoverable save/grow failure path)
 - Tealet was left in an unusable state by an internal failure path
@@ -1319,7 +1319,7 @@ Target tealet is defunct (invalid for switching).
 
 **Example:**
 ```c
-int result = tealet_switch(t, &arg, TEALET_SWITCH_DEFAULT);
+int result = tealet_switch(t, &arg, TEALET_XFER_DEFAULT);
 if (result == TEALET_ERR_DEFUNCT) {
     fprintf(stderr, "Tealet has exited\n");
     tealet_delete(t);
@@ -1339,7 +1339,7 @@ Switch result signaling explicit panic-tagged resume.
 
 **When returned:**
 - Returned by `tealet_switch()` when the resumed tealet was targeted via
-    `tealet_exit(..., TEALET_EXIT_PANIC)` or `tealet_switch(..., TEALET_SWITCH_PANIC)`.
+    `tealet_exit(..., TEALET_XFER_PANIC)` or `tealet_switch(..., TEALET_XFER_PANIC)`.
 
 **Recovery:**
 - Treat as fatal control-flow anomaly for the coroutine workflow.
@@ -1362,22 +1362,18 @@ Switch result signaling explicit panic-tagged resume.
 ### Flags
 
 ```c
-/* Exit flags (new names) */
-#define TEALET_EXIT_DEFAULT 0  /* Don't auto-delete */
+/* Transfer flags (shared by tealet_switch() and tealet_exit()) */
+#define TEALET_XFER_DEFAULT 0  /* Default transfer behavior */
+#define TEALET_XFER_FORCE   4  /* Force transfer despite save-time memory failures */
+#define TEALET_XFER_PANIC   8  /* Mark receiving tealet as panic-resumed */
+#define TEALET_XFER_NOFAIL 16  /* Retry with FORCE, then panic+force to main */
+
+/* Exit-only flags */
 #define TEALET_EXIT_DELETE  1  /* Auto-delete on exit; pointers to exiting tealet become invalid */
 #define TEALET_EXIT_DEFER   2  /* Defer exit to return */
-#define TEALET_EXIT_FORCE   4  /* Force exit despite save-time memory failures */
-#define TEALET_EXIT_PANIC   8  /* Mark receiving tealet as panic-resumed */
-#define TEALET_EXIT_NOFAIL 16  /* Retry with FORCE, then panic+force to main */
-
-/* Switch flags */
-#define TEALET_SWITCH_DEFAULT 0  /* Default switch behavior */
-#define TEALET_SWITCH_FORCE   4  /* Force switch despite save-time memory failures */
-#define TEALET_SWITCH_PANIC   8  /* Mark receiving tealet as panic-resumed */
-#define TEALET_SWITCH_NOFAIL 16  /* Retry with FORCE, then panic+force to main */
 ```
 
-Used with `tealet_exit()`.
+Used with `tealet_switch()` and `tealet_exit()`.
 
 ---
 
@@ -1404,7 +1400,7 @@ tealet_run(t1, func1, NULL, NULL, TEALET_RUN_DEFAULT);
 tealet_run(t2, func2, NULL, NULL, TEALET_RUN_DEFAULT);
 setup_relationship(t1, t2);  /* Both exist but not started */
 void *arg = t2;
-tealet_switch(t1, &arg, TEALET_SWITCH_DEFAULT);  /* Now start t1 */
+tealet_switch(t1, &arg, TEALET_XFER_DEFAULT);  /* Now start t1 */
 
 /* Pattern 2: Immediate start (more concise) */
 void *arg = my_data;
@@ -1452,7 +1448,7 @@ tealet_t *nested_run(tealet_t *current, void *arg) {
 void helper(tealet_t *current) {
     if (error_condition) {
         void *error = make_error();
-        tealet_exit(current->main, &error, TEALET_EXIT_DELETE | TEALET_EXIT_NOFAIL);
+        tealet_exit(current->main, &error, TEALET_EXIT_DELETE | TEALET_XFER_NOFAIL);
         /* Never returns */
     }
 }
@@ -1541,7 +1537,7 @@ tealet_t *counter_run(tealet_t *current, void *arg) {
     while (state->current < state->max) {
         void *value = (void*)(intptr_t)state->current;
         state->current++;
-        tealet_switch(current->main, &value, TEALET_SWITCH_DEFAULT);
+        tealet_switch(current->main, &value, TEALET_XFER_DEFAULT);
     }
     
     return current->main;
@@ -1567,7 +1563,7 @@ int main(void) {
     /* Start it */
     int max = 5;
     void *arg = &max;
-    int result = tealet_switch(counter, &arg, TEALET_SWITCH_DEFAULT);
+    int result = tealet_switch(counter, &arg, TEALET_XFER_DEFAULT);
     if (result != 0) {
         fprintf(stderr, "Switch failed: %d\n", result);
         tealet_delete(counter);
@@ -1580,7 +1576,7 @@ int main(void) {
         int value = (int)(intptr_t)arg;
         printf("Value: %d\n", value);
         
-        result = tealet_switch(counter, &arg, TEALET_SWITCH_DEFAULT);
+        result = tealet_switch(counter, &arg, TEALET_XFER_DEFAULT);
         if (result != 0) {
             fprintf(stderr, "Switch failed: %d\n", result);
             break;

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -123,7 +123,7 @@ tealet_t *my_run(tealet_t *current, void *arg) {
     void *ptr = &local_value;
     
     /* DANGER: Switching invalidates local_value */
-    tealet_switch(current->main, &ptr, TEALET_SWITCH_DEFAULT);
+    tealet_switch(current->main, &ptr, TEALET_XFER_DEFAULT);
     /* ptr now points to invalid stack data */
     
     return current->main;
@@ -139,7 +139,7 @@ tealet_t *my_run(tealet_t *current, void *arg) {
     *heap_value = 42;
     void *ptr = heap_value;
     
-    tealet_switch(current->main, &ptr, TEALET_SWITCH_DEFAULT);
+    tealet_switch(current->main, &ptr, TEALET_XFER_DEFAULT);
     /* ptr still valid */
     
     free(heap_value);
@@ -205,10 +205,10 @@ int main(void) {
 
 ### Exit Flags
 
-- `TEALET_EXIT_DEFAULT` (0): **Keep tealet allocated**; tealet must be manually deleted with `tealet_delete()`
+- `TEALET_XFER_DEFAULT` (0): **Keep tealet allocated**; tealet must be manually deleted with `tealet_delete()`
 - `TEALET_EXIT_DELETE`: **Auto-delete on exit**; any tealet pointers to the exiting tealet become invalid after transfer
 - `TEALET_EXIT_DEFER`: **Defer exit transfer policy to run function return** (advanced; see API docs)
-- `TEALET_EXIT_NOFAIL`: **Enable robust fallback retries** without manual recovery logic
+- `TEALET_XFER_NOFAIL`: **Enable robust fallback retries** without manual recovery logic
 
 ### Shutdown Order Requirement
 
@@ -236,9 +236,9 @@ tealet_t *fire_and_forget(tealet_t *current, void *arg) {
 tealet_t *controlled_worker(tealet_t *current, void *arg) {
     while (should_continue()) {
         do_work();
-        tealet_switch(current->main, NULL, TEALET_SWITCH_DEFAULT);  /* Yield back */
+        tealet_switch(current->main, NULL, TEALET_XFER_DEFAULT);  /* Yield back */
     }
-    tealet_exit(current->main, NULL, TEALET_EXIT_DEFAULT | TEALET_EXIT_NOFAIL);  /* Don't auto-delete */
+    tealet_exit(current->main, NULL, TEALET_XFER_DEFAULT | TEALET_XFER_NOFAIL);  /* Don't auto-delete */
     return current->main;
 }
 
@@ -249,8 +249,8 @@ int main(void) {
     tealet_run(worker, controlled_worker, &arg, NULL, TEALET_RUN_SWITCH);
     
     /* Can switch back to worker multiple times */
-    tealet_switch(worker, NULL, TEALET_SWITCH_DEFAULT);
-    tealet_switch(worker, NULL, TEALET_SWITCH_DEFAULT);
+    tealet_switch(worker, NULL, TEALET_XFER_DEFAULT);
+    tealet_switch(worker, NULL, TEALET_XFER_DEFAULT);
     
     /* Manual cleanup when done */
     tealet_delete(worker);
@@ -271,7 +271,7 @@ tealet_t *ping_run(tealet_t *current, void *arg) {
     
     for (int i = 0; i < 3; i++) {
         printf("Ping %d\n", i);
-        tealet_switch(pong, NULL, TEALET_SWITCH_DEFAULT);
+        tealet_switch(pong, NULL, TEALET_XFER_DEFAULT);
     }
     
     return current->main;
@@ -282,7 +282,7 @@ tealet_t *pong_run(tealet_t *current, void *arg) {
     
     for (int i = 0; i < 3; i++) {
         printf("  Pong %d\n", i);
-        tealet_switch(ping, NULL, TEALET_SWITCH_DEFAULT);
+        tealet_switch(ping, NULL, TEALET_XFER_DEFAULT);
     }
     
     return current->main;
@@ -302,11 +302,11 @@ int main(void) {
     
     /* Start ping, passing pong as argument */
     void *arg = pong;
-    tealet_switch(ping, &arg, TEALET_SWITCH_DEFAULT);
+    tealet_switch(ping, &arg, TEALET_XFER_DEFAULT);
     
     /* Start pong, passing ping as argument */
     arg = ping;
-    tealet_switch(pong, &arg, TEALET_SWITCH_DEFAULT);
+    tealet_switch(pong, &arg, TEALET_XFER_DEFAULT);
     
     tealet_delete(ping);
     tealet_delete(pong);
@@ -337,7 +337,7 @@ tealet_t *range_run(tealet_t *current, void *arg) {
     for (int i = 0; i < max; i++) {
         /* Yield value back to caller */
         void *value = (void*)(intptr_t)i;
-        tealet_switch(current->main, &value, TEALET_SWITCH_DEFAULT);
+        tealet_switch(current->main, &value, TEALET_XFER_DEFAULT);
     }
     
     return current->main;
@@ -357,7 +357,7 @@ int main(void) {
     /* Pull values from generator */
     while (tealet_status(gen) == TEALET_STATUS_ACTIVE) {
         printf("%d\n", (int)(intptr_t)arg);
-        tealet_switch(gen, &arg, TEALET_SWITCH_DEFAULT);
+        tealet_switch(gen, &arg, TEALET_XFER_DEFAULT);
     }
     
     tealet_delete(gen);
@@ -396,7 +396,7 @@ tealet_t *producer_run(tealet_t *current, void *arg) {
         printf("Produced: %d\n", *ctx->buffer);
         
         /* Switch to consumer */
-        tealet_switch(ctx->consumer, NULL, TEALET_SWITCH_DEFAULT);
+        tealet_switch(ctx->consumer, NULL, TEALET_XFER_DEFAULT);
     }
     
     return current->main;
@@ -412,7 +412,7 @@ tealet_t *consumer_run(tealet_t *current, void *arg) {
         ctx->count++;
         
         /* Switch back to producer */
-        tealet_switch(producer, NULL, TEALET_SWITCH_DEFAULT);
+        tealet_switch(producer, NULL, TEALET_XFER_DEFAULT);
     }
     
     return current->main;
@@ -469,7 +469,7 @@ tealet_run(t, my_run, NULL, NULL, TEALET_RUN_DEFAULT);
 /* Tealet created but not yet running */
 
 void *arg = my_data;
-tealet_switch(t, &arg, TEALET_SWITCH_DEFAULT);  /* Now it starts */
+tealet_switch(t, &arg, TEALET_XFER_DEFAULT);  /* Now it starts */
 ```
 
 Use when you need to set up multiple coroutines before starting any.
@@ -485,7 +485,7 @@ if (tealet_run(t, my_run, NULL, NULL, TEALET_RUN_DEFAULT) != 0) {
     return TEALET_ERR_MEM;
 }
 
-int result = tealet_switch(t, &arg, TEALET_SWITCH_DEFAULT);
+int result = tealet_switch(t, &arg, TEALET_XFER_DEFAULT);
 if (result == TEALET_ERR_DEFUNCT) {
     fprintf(stderr, "Target tealet is corrupt\n");
     return -1;

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1838,7 +1838,7 @@ static int tealet_xfer_inner(tealet_t *target, void *in_arg, void **out_arg, int
   result = tealet_switchstack(g_main, g_target, in_arg, out_arg);
 
   if (result < 0) {
-    g_current->flags &= ~(TEALET_TFLAGS_EXITING | TEALET_TFLAGS_AUTODELETE);
+    g_current->flags &= ~(TEALET_TFLAGS_EXITING | TEALET_TFLAGS_AUTODELETE | TEALET_TFLAGS_SAVEFORCE);
   }
 
   if (is_exit) {

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1429,7 +1429,7 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
     /* Resolve any deferred-exit state explicitly so implicit return uses one
      * consistent (target,arg,flags) policy.
      */
-    exit_flags = TEALET_EXIT_DEFAULT;
+    exit_flags = TEALET_XFER_DEFAULT;
     exit_arg = NULL;
     if (g_main->g_flags & TEALET_EXIT_DEFER) {
       exit_flags = g_main->g_flags & (~TEALET_EXIT_DEFER);
@@ -1438,7 +1438,7 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
       g_main->g_arg = NULL;
     }
 
-    result = tealet_exit((tealet_t *)g_exit_target, exit_arg, exit_flags | TEALET_EXIT_NOFAIL);
+    result = tealet_exit((tealet_t *)g_exit_target, exit_arg, exit_flags | TEALET_XFER_NOFAIL);
     (void)result;
     assert(!"Implicit return transfer failed");
     abort();
@@ -1788,8 +1788,8 @@ static int tealet_switch_inner(tealet_t *stub, void **parg, int flags) {
   if ((g_target->flags & TEALET_TFLAGS_BOUND) == 0)
     return TEALET_ERR_INVAL;
 
-  force_requested = ((flags & TEALET_SWITCH_FORCE) != 0);
-  panic_requested = ((flags & TEALET_SWITCH_PANIC) != 0);
+  force_requested = ((flags & TEALET_XFER_FORCE) != 0);
+  panic_requested = ((flags & TEALET_XFER_PANIC) != 0);
 
   if (force_requested)
     g_current->flags |= TEALET_TFLAGS_EXITFORCE;
@@ -1819,20 +1819,20 @@ int tealet_switch(tealet_t *stub, void **parg, int flags) {
   int result;
   tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
 
-  assert((flags & ~(TEALET_SWITCH_FORCE | TEALET_SWITCH_PANIC | TEALET_SWITCH_NOFAIL)) == 0);
+  assert((flags & ~(TEALET_XFER_FORCE | TEALET_XFER_PANIC | TEALET_XFER_NOFAIL)) == 0);
 
   g_current = g_main->g_current;
   tealet_verify_current_matches_caller(g_current);
   tealet_lock_switch(g_main);
 
   flags_used = flags;
-  if (flags_used & TEALET_SWITCH_NOFAIL) {
-    flags_used &= ~TEALET_SWITCH_NOFAIL;
-    retry_flags = flags_used | TEALET_SWITCH_FORCE;
+  if (flags_used & TEALET_XFER_NOFAIL) {
+    flags_used &= ~TEALET_XFER_NOFAIL;
+    retry_flags = flags_used | TEALET_XFER_FORCE;
 
     result = tealet_switch_inner(stub, parg, retry_flags);
     if (result == TEALET_ERR_MEM || result == TEALET_ERR_DEFUNCT) {
-      retry_flags = flags_used | TEALET_SWITCH_PANIC | TEALET_SWITCH_FORCE;
+      retry_flags = flags_used | TEALET_XFER_PANIC | TEALET_XFER_FORCE;
       result = tealet_switch_inner((tealet_t *)g_main, parg, retry_flags);
     }
   } else {
@@ -1858,9 +1858,9 @@ static int tealet_exit_inner(tealet_t *target, void *arg, int flags) {
     return TEALET_ERR_INVAL;
 
   g_current->flags |= TEALET_TFLAGS_EXITING;
-  if (flags & TEALET_EXIT_FORCE)
+  if (flags & TEALET_XFER_FORCE)
     g_current->flags |= TEALET_TFLAGS_EXITFORCE;
-  panic_requested = ((flags & TEALET_EXIT_PANIC) != 0);
+  panic_requested = ((flags & TEALET_XFER_PANIC) != 0);
   if (panic_requested)
     g_main->g_flags |= TEALET_MFLAGS_PANIC;
   assert(g_current->stack == NULL);
@@ -1896,8 +1896,8 @@ int tealet_exit(tealet_t *target, void *arg, int flags) {
   int result;
 
   assert((flags &
-          ~(TEALET_EXIT_DELETE | TEALET_EXIT_DEFER | TEALET_EXIT_FORCE | TEALET_EXIT_PANIC | TEALET_EXIT_NOFAIL)) == 0);
-  assert(!((flags & TEALET_EXIT_DEFER) && (flags & TEALET_EXIT_PANIC)));
+          ~(TEALET_EXIT_DELETE | TEALET_EXIT_DEFER | TEALET_XFER_FORCE | TEALET_XFER_PANIC | TEALET_XFER_NOFAIL)) == 0);
+  assert(!((flags & TEALET_EXIT_DEFER) && (flags & TEALET_XFER_PANIC)));
 
   g_current = g_main->g_current;
   tealet_verify_current_matches_caller(g_current);
@@ -1925,13 +1925,13 @@ int tealet_exit(tealet_t *target, void *arg, int flags) {
     g_main->g_arg = 0;
   }
   flags_used = flags;
-  if (flags_used & TEALET_EXIT_NOFAIL) {
-    flags_used &= ~TEALET_EXIT_NOFAIL;
-    retry_flags = flags_used | TEALET_EXIT_FORCE;
+  if (flags_used & TEALET_XFER_NOFAIL) {
+    flags_used &= ~TEALET_XFER_NOFAIL;
+    retry_flags = flags_used | TEALET_XFER_FORCE;
 
     result = tealet_exit_inner(target, arg, retry_flags);
     if (result == TEALET_ERR_MEM || result == TEALET_ERR_DEFUNCT) {
-      retry_flags = flags_used | TEALET_EXIT_PANIC | TEALET_EXIT_FORCE;
+      retry_flags = flags_used | TEALET_XFER_PANIC | TEALET_XFER_FORCE;
       result = tealet_exit_inner((tealet_t *)g_main, arg, retry_flags);
     }
   } else {

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1059,14 +1059,14 @@ static int tealet_stack_grow_list(tealet_main_t *main, tealet_stack_t *list, cha
  * save and restore logic using previously defined functions
  */
 
-  /** main->g_target contains the tealet we are switching to:
+/** main->g_target contains the tealet we are switching to:
  * target->stack_far is the limit to which we must save the old stack
  * target->stack can be NULL, indicating that the target stack
  * needs not be restored.
-   *
-   * One-shot transfer signals consumed here:
-   * - current->SAVEFORCE: read once for this save operation, then cleared.
-   * - current->EXITING/AUTODELETE: consumed when exiting path is taken.
+ *
+ * One-shot transfer signals consumed here:
+ * - current->SAVEFORCE: read once for this save operation, then cleared.
+ * - current->EXITING/AUTODELETE: consumed when exiting path is taken.
  */
 static int tealet_save_state(tealet_main_t *g_main, void *old_stack_pointer) {
   tealet_sub_t *g_target = g_main->g_target;
@@ -1263,10 +1263,10 @@ static int tealet_switchstack(tealet_main_t *g_main, tealet_sub_t *target, void 
 
   /* Locking is owned by top-level switching APIs (new/create/switch/exit/fork).
    * This helper assumes the caller already established the desired lock scope.
-    *
-    * PANIC is a one-shot transfer signal (set before calling this helper).
-    * This helper always consumes/clears PANIC before returning, on both
-    * success and error paths.
+   *
+   * PANIC is a one-shot transfer signal (set before calling this helper).
+   * This helper always consumes/clears PANIC before returning, on both
+   * success and error paths.
    */
 
   if (target->flags & TEALET_TFLAGS_EXITED) {
@@ -1332,7 +1332,7 @@ static int tealet_switchstack(tealet_main_t *g_main, tealet_sub_t *target, void 
 #if TEALET_WITH_STACK_GUARD
     tealet_guard_protect_current(g_main);
 #endif
-  g_main->g_flags &= ~TEALET_MFLAGS_PANIC;
+    g_main->g_flags &= ~TEALET_MFLAGS_PANIC;
     return TEALET_ERR_MEM;
   }
   g_main->g_target = NULL;

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -40,10 +40,16 @@
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
-/* Internal main-tealet flags (stored in tealet_main_t::g_flags). */
+/* Internal main-tealet flags (stored in tealet_main_t::g_flags).
+ * One-shot transfer signals are set by xfer preparation and consumed/cleared
+ * by tealet_switchstack().
+ */
 #define TEALET_MFLAGS_PANIC (1 << 16)
 
-/* Internal per-tealet flags (stored in tealet_sub_t::flags). */
+/* Internal per-tealet flags (stored in tealet_sub_t::flags).
+ * TEALET_TFLAGS_SAVEFORCE is a one-shot transfer signal set by xfer
+ * preparation and consumed/cleared by tealet_save_state().
+ */
 #define TEALET_TFLAGS_BOUND (1u << 0)
 #define TEALET_TFLAGS_EXITING (1u << 1)
 #define TEALET_TFLAGS_EXITED (1u << 2)
@@ -51,7 +57,7 @@
 #define TEALET_TFLAGS_MAIN_LINEAGE (1u << 4)
 #define TEALET_TFLAGS_FORK (1u << 5)
 #define TEALET_TFLAGS_AUTODELETE (1u << 6)
-#define TEALET_TFLAGS_EXITFORCE (1u << 7)
+#define TEALET_TFLAGS_SAVEFORCE (1u << 7)
 
 /* Internal per-stack flags (stored in tealet_stack_t::flags). */
 #define TEALET_SFLAGS_DEFUNCT (1u << 0)
@@ -1053,10 +1059,14 @@ static int tealet_stack_grow_list(tealet_main_t *main, tealet_stack_t *list, cha
  * save and restore logic using previously defined functions
  */
 
-/** main->g_target contains the tealet we are switching to:
+  /** main->g_target contains the tealet we are switching to:
  * target->stack_far is the limit to which we must save the old stack
  * target->stack can be NULL, indicating that the target stack
  * needs not be restored.
+   *
+   * One-shot transfer signals consumed here:
+   * - current->SAVEFORCE: read once for this save operation, then cleared.
+   * - current->EXITING/AUTODELETE: consumed when exiting path is taken.
  */
 static int tealet_save_state(tealet_main_t *g_main, void *old_stack_pointer) {
   tealet_sub_t *g_target = g_main->g_target;
@@ -1070,7 +1080,9 @@ static int tealet_save_state(tealet_main_t *g_main, void *old_stack_pointer) {
   assert(g_current != g_target);
 
   exiting = ((g_current->flags & TEALET_TFLAGS_EXITING) != 0);
-  force = ((g_current->flags & TEALET_TFLAGS_EXITFORCE) != 0);
+  force = ((g_current->flags & TEALET_TFLAGS_SAVEFORCE) != 0);
+  /* SAVEFORCE is transient: it only influences this save operation. */
+  g_current->flags &= ~TEALET_TFLAGS_SAVEFORCE;
   /* Force mode requests non-failable save behavior under memory pressure.
    * A stack that cannot be saved may be marked defunct so the switch can
    * proceed. The main tealet is never marked defunct; forced saves from main
@@ -1097,7 +1109,7 @@ static int tealet_save_state(tealet_main_t *g_main, void *old_stack_pointer) {
     /* tealet is exiting. We don't save its stack. */
     assert(!TEALET_IS_MAIN((tealet_t *)g_current));
     auto_delete = ((g_current->flags & TEALET_TFLAGS_AUTODELETE) != 0);
-    g_current->flags &= ~(TEALET_TFLAGS_EXITING | TEALET_TFLAGS_AUTODELETE | TEALET_TFLAGS_EXITFORCE);
+    g_current->flags &= ~(TEALET_TFLAGS_EXITING | TEALET_TFLAGS_AUTODELETE | TEALET_TFLAGS_SAVEFORCE);
     g_current->flags |= TEALET_TFLAGS_EXITED;
     if (auto_delete) {
       /* auto-delete the tealet */
@@ -1251,9 +1263,14 @@ static int tealet_switchstack(tealet_main_t *g_main, tealet_sub_t *target, void 
 
   /* Locking is owned by top-level switching APIs (new/create/switch/exit/fork).
    * This helper assumes the caller already established the desired lock scope.
+    *
+    * PANIC is a one-shot transfer signal (set before calling this helper).
+    * This helper always consumes/clears PANIC before returning, on both
+    * success and error paths.
    */
 
   if (target->flags & TEALET_TFLAGS_EXITED) {
+    g_main->g_flags &= ~TEALET_MFLAGS_PANIC;
     return TEALET_ERR_INVAL;
   }
 
@@ -1267,11 +1284,13 @@ static int tealet_switchstack(tealet_main_t *g_main, tealet_sub_t *target, void 
    * -2 = error, target tealet corrupt
    */
   if (tealet_is_defunct(target)) {
+    g_main->g_flags &= ~TEALET_MFLAGS_PANIC;
     return TEALET_ERR_DEFUNCT;
   }
 
   err_result = tealet_check_caller_is_current(g_main->g_current);
   if (err_result) {
+    g_main->g_flags &= ~TEALET_MFLAGS_PANIC;
     return err_result;
   }
 
@@ -1284,6 +1303,7 @@ static int tealet_switchstack(tealet_main_t *g_main, tealet_sub_t *target, void 
    * continued execution after reporting the error.
    */
   {
+    g_main->g_flags &= ~TEALET_MFLAGS_PANIC;
     return err_result;
   }
 
@@ -1312,6 +1332,7 @@ static int tealet_switchstack(tealet_main_t *g_main, tealet_sub_t *target, void 
 #if TEALET_WITH_STACK_GUARD
     tealet_guard_protect_current(g_main);
 #endif
+  g_main->g_flags &= ~TEALET_MFLAGS_PANIC;
     return TEALET_ERR_MEM;
   }
   g_main->g_target = NULL;
@@ -1777,36 +1798,53 @@ done:
  * the lock internally.
  */
 
-static int tealet_switch_inner(tealet_t *stub, void **parg, int flags) {
-  tealet_sub_t *g_target = (tealet_sub_t *)stub;
+static int tealet_xfer_inner(tealet_t *target, void *in_arg, void **out_arg, int flags, int is_exit) {
+  tealet_sub_t *g_target = (tealet_sub_t *)target;
   tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
   tealet_sub_t *g_current = g_main->g_current;
-  int force_requested;
   int panic_requested;
   int result;
 
   if ((g_target->flags & TEALET_TFLAGS_BOUND) == 0)
     return TEALET_ERR_INVAL;
 
-  force_requested = ((flags & TEALET_XFER_FORCE) != 0);
+  if (is_exit) {
+    assert(g_current != (tealet_sub_t *)g_main); /* mustn't exit main */
+    if (g_target == g_current)
+      return TEALET_ERR_INVAL; /* invalid tealet */
+    g_current->flags |= TEALET_TFLAGS_EXITING;
+    assert(g_current->stack == NULL);
+    assert((g_current->flags & TEALET_TFLAGS_AUTODELETE) == 0);
+    if (flags & TEALET_EXIT_DELETE)
+      g_current->flags |= TEALET_TFLAGS_AUTODELETE;
+  } else {
+    if (g_target == g_current) {
+      panic_requested = ((flags & TEALET_XFER_PANIC) != 0);
+      g_main->g_previous = g_current;
+      return panic_requested ? TEALET_ERR_PANIC : 0; /* switch to self */
+    }
+  }
+
   panic_requested = ((flags & TEALET_XFER_PANIC) != 0);
 
-  if (force_requested)
-    g_current->flags |= TEALET_TFLAGS_EXITFORCE;
+  /* One-shot transfer signals are staged here before transfer and consumed by
+   * lower-level transfer machinery.
+   */
+  if (flags & TEALET_XFER_FORCE)
+    g_current->flags |= TEALET_TFLAGS_SAVEFORCE;
   if (panic_requested)
     g_main->g_flags |= TEALET_MFLAGS_PANIC;
 
-  if (g_target == g_current) {
-    g_main->g_previous = g_current;
-    result = panic_requested ? TEALET_ERR_PANIC : 0; /* switch to self */
-  } else {
-    result = tealet_switchstack(g_main, g_target, parg ? *parg : NULL, parg);
+  result = tealet_switchstack(g_main, g_target, in_arg, out_arg);
+
+  if (result < 0) {
+    g_current->flags &= ~(TEALET_TFLAGS_EXITING | TEALET_TFLAGS_AUTODELETE);
   }
 
-  if (panic_requested && result < 0)
-    g_main->g_flags &= ~TEALET_MFLAGS_PANIC;
-  if (force_requested)
-    g_current->flags &= ~TEALET_TFLAGS_EXITFORCE;
+  if (is_exit) {
+    assert(result != TEALET_ERR_PANIC);
+    assert(result < 0); /* only return here if there was failure */
+  }
 
   return result;
 }
@@ -1814,6 +1852,8 @@ static int tealet_switch_inner(tealet_t *stub, void **parg, int flags) {
 int tealet_switch(tealet_t *stub, void **parg, int flags) {
   tealet_sub_t *g_target = (tealet_sub_t *)stub;
   tealet_sub_t *g_current;
+  void *in_arg;
+  void **out_arg;
   int flags_used;
   int retry_flags;
   int result;
@@ -1824,58 +1864,24 @@ int tealet_switch(tealet_t *stub, void **parg, int flags) {
   g_current = g_main->g_current;
   tealet_verify_current_matches_caller(g_current);
   tealet_lock_switch(g_main);
+  in_arg = parg ? *parg : NULL;
+  out_arg = parg;
 
   flags_used = flags;
   if (flags_used & TEALET_XFER_NOFAIL) {
     flags_used &= ~TEALET_XFER_NOFAIL;
     retry_flags = flags_used | TEALET_XFER_FORCE;
 
-    result = tealet_switch_inner(stub, parg, retry_flags);
+    result = tealet_xfer_inner(stub, in_arg, out_arg, retry_flags, 0);
     if (result == TEALET_ERR_MEM || result == TEALET_ERR_DEFUNCT) {
       retry_flags = flags_used | TEALET_XFER_PANIC | TEALET_XFER_FORCE;
-      result = tealet_switch_inner((tealet_t *)g_main, parg, retry_flags);
+      result = tealet_xfer_inner((tealet_t *)g_main, in_arg, out_arg, retry_flags, 0);
     }
   } else {
-    result = tealet_switch_inner(stub, parg, flags_used);
+    result = tealet_xfer_inner(stub, in_arg, out_arg, flags_used, 0);
   }
 
   tealet_unlock_switch(g_main);
-  return result;
-}
-
-static int tealet_exit_inner(tealet_t *target, void *arg, int flags) {
-  tealet_sub_t *g_target = (tealet_sub_t *)target;
-  tealet_main_t *g_main = TEALET_GET_MAIN(g_target);
-  tealet_sub_t *g_current = g_main->g_current;
-  char *stack_far = g_target->stack_far;
-  int panic_requested;
-  int result;
-
-  assert(g_current != (tealet_sub_t *)g_main); /* mustn't exit main */
-  if (g_target == g_current)
-    return TEALET_ERR_INVAL; /* invalid tealet */
-  if ((g_target->flags & TEALET_TFLAGS_BOUND) == 0)
-    return TEALET_ERR_INVAL;
-
-  g_current->flags |= TEALET_TFLAGS_EXITING;
-  if (flags & TEALET_XFER_FORCE)
-    g_current->flags |= TEALET_TFLAGS_EXITFORCE;
-  panic_requested = ((flags & TEALET_XFER_PANIC) != 0);
-  if (panic_requested)
-    g_main->g_flags |= TEALET_MFLAGS_PANIC;
-  assert(g_current->stack == NULL);
-  assert((g_current->flags & TEALET_TFLAGS_AUTODELETE) == 0);
-  if (flags & TEALET_EXIT_DELETE)
-    g_current->flags |= TEALET_TFLAGS_AUTODELETE;
-  result = tealet_switchstack(g_main, g_target, arg, NULL);
-  assert(result < 0); /* only return here if there was failure */
-  if (panic_requested)
-    g_main->g_flags &= ~TEALET_MFLAGS_PANIC;
-  g_target->stack_far = stack_far;
-  g_current->stack = NULL;
-  g_current->flags &= ~(TEALET_TFLAGS_EXITING | TEALET_TFLAGS_AUTODELETE | TEALET_TFLAGS_EXITFORCE);
-  /* verify that we don't get the switch-back code PANIC */
-  assert(result != TEALET_ERR_PANIC); /* panic should be handled by caller if requested */
   return result;
 }
 
@@ -1929,13 +1935,13 @@ int tealet_exit(tealet_t *target, void *arg, int flags) {
     flags_used &= ~TEALET_XFER_NOFAIL;
     retry_flags = flags_used | TEALET_XFER_FORCE;
 
-    result = tealet_exit_inner(target, arg, retry_flags);
+    result = tealet_xfer_inner(target, arg, NULL, retry_flags, 1);
     if (result == TEALET_ERR_MEM || result == TEALET_ERR_DEFUNCT) {
       retry_flags = flags_used | TEALET_XFER_PANIC | TEALET_XFER_FORCE;
-      result = tealet_exit_inner((tealet_t *)g_main, arg, retry_flags);
+      result = tealet_xfer_inner((tealet_t *)g_main, arg, NULL, retry_flags, 1);
     }
   } else {
-    result = tealet_exit_inner(target, arg, flags_used);
+    result = tealet_xfer_inner(target, arg, NULL, flags_used, 1);
   }
 
   tealet_unlock_switch(g_main);

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -333,7 +333,7 @@ int tealet_run(tealet_t *tealet, tealet_run_t run, void **parg, void *stack_far,
  *   } else if (result > 0) {
  *       // This is the parent tealet
  *       // ... parent-specific code ...
- *       tealet_switch(child, &arg, TEALET_SWITCH_DEFAULT); // Switch to child when ready
+ *       tealet_switch(child, &arg, TEALET_XFER_DEFAULT); // Switch to child when ready
  *   } else {
  *       // Error occurred (result < 0)
  *   }
@@ -353,26 +353,26 @@ int tealet_fork(tealet_t *tealet, tealet_t **pother, void **parg, int flags);
  * @brief Suspend current tealet and resume @p target.
  * @param target Tealet to switch to; must share the same main tealet and thread.
  * @param parg In/out argument pointer passed across switches; may be NULL.
- * @param flags Switch behavior bits: #TEALET_SWITCH_DEFAULT, #TEALET_SWITCH_FORCE,
- * #TEALET_SWITCH_PANIC, #TEALET_SWITCH_NOFAIL.
+ * @param flags Switch behavior bits: #TEALET_XFER_DEFAULT, #TEALET_XFER_FORCE,
+ * #TEALET_XFER_PANIC, #TEALET_XFER_NOFAIL.
  * @retval 0 Success.
  * @retval TEALET_ERR_MEM Save/restore failed due to memory pressure.
  * @retval TEALET_ERR_DEFUNCT Target tealet/stack is defunct.
  * @retval TEALET_ERR_PANIC Resumed due to panic-tagged transfer.
  * @retval TEALET_ERR_INVAL Invalid state/target.
  *
- * With #TEALET_SWITCH_FORCE, save-time memory failures may defunct
+ * With #TEALET_XFER_FORCE, save-time memory failures may defunct
  * intermediate non-main saved stacks to complete the requested transfer.
  * #TEALET_ERR_MEM can still be returned with FORCE when only main-stack
  * growth would allow progress, because main is never marked defunct.
  *
- * #TEALET_SWITCH_PANIC requests panic delivery to the receiving tealet as
+ * #TEALET_XFER_PANIC requests panic delivery to the receiving tealet as
  * #TEALET_ERR_PANIC on its resumed switch return path.
  *
- * #TEALET_SWITCH_NOFAIL applies retry/fallback policy: first attempt with
+ * #TEALET_XFER_NOFAIL applies retry/fallback policy: first attempt with
  * FORCE, then panic+force fallback to main only on #TEALET_ERR_MEM/
  * #TEALET_ERR_DEFUNCT. Other errors are returned unchanged.
- * When @p target is main, #TEALET_SWITCH_NOFAIL is guaranteed to succeed,
+ * When @p target is main, #TEALET_XFER_NOFAIL is guaranteed to succeed,
  * because main is never allowed to become defunct.
  *
  * @warning Do not pass stack-allocated cross-tealet payloads through @p parg.
@@ -380,48 +380,44 @@ int tealet_fork(tealet_t *tealet, tealet_t **pother, void **parg, int flags);
 TEALET_API
 int tealet_switch(tealet_t *target, void **parg, int flags);
 
-/* Switch flags */
-#define TEALET_SWITCH_DEFAULT 0 /* default switch behavior */
-#define TEALET_SWITCH_FORCE 4   /* force switch despite save-time memory failures */
-#define TEALET_SWITCH_PANIC 8   /* mark the receiving tealet as panic-resumed */
-#define TEALET_SWITCH_NOFAIL 16 /* retry with FORCE and panic-to-main fallback */
+/* Transfer flags shared by tealet_switch() and tealet_exit() */
+#define TEALET_XFER_DEFAULT 0 /* default transfer behavior */
+#define TEALET_XFER_FORCE 4   /* force transfer despite save-time memory failures */
+#define TEALET_XFER_PANIC 8   /* mark the receiving tealet as panic-resumed */
+#define TEALET_XFER_NOFAIL 16 /* retry with FORCE and panic-to-main fallback */
 
-/* Exit flags */
-#define TEALET_EXIT_DEFAULT 0 /* Don't auto-delete */
-#define TEALET_EXIT_DELETE 1  /* Auto-delete on exit; pointers to exiting tealet become invalid */
-#define TEALET_EXIT_DEFER 2   /* Defer exit to return statement */
-#define TEALET_EXIT_FORCE 4   /* Force exit switch despite save-time memory failures */
-#define TEALET_EXIT_PANIC 8   /* Mark the receiving tealet as panic-resumed */
-#define TEALET_EXIT_NOFAIL 16 /* Retry with FORCE and panic-to-main fallback */
+/* Exit-only flags */
+#define TEALET_EXIT_DELETE 1 /* Auto-delete on exit; pointers to exiting tealet become invalid */
+#define TEALET_EXIT_DEFER 2  /* Defer exit to return statement */
 
 /**
  * @brief Exit current tealet and transfer control to @p target.
  * @param target Requested target tealet.
  * @param arg Optional argument to deliver to @p target.
- * @param flags Exit behavior bits: #TEALET_EXIT_DEFAULT, #TEALET_EXIT_DELETE,
- * #TEALET_EXIT_DEFER, #TEALET_EXIT_FORCE, #TEALET_EXIT_PANIC,
- * #TEALET_EXIT_NOFAIL.
+ * @param flags Exit behavior bits: #TEALET_XFER_DEFAULT, #TEALET_EXIT_DELETE,
+ * #TEALET_EXIT_DEFER, #TEALET_XFER_FORCE, #TEALET_XFER_PANIC,
+ * #TEALET_XFER_NOFAIL.
  * @return 0 only for deferred setup path; otherwise returns a negative error code if transfer cannot start.
  *
- * Without #TEALET_EXIT_FORCE, memory pressure while saving state returns #TEALET_ERR_MEM.
- * With #TEALET_EXIT_FORCE, save-time memory failures may defunct intermediate stacks
+ * Without #TEALET_XFER_FORCE, memory pressure while saving state returns #TEALET_ERR_MEM.
+ * With #TEALET_XFER_FORCE, save-time memory failures may defunct intermediate stacks
  * to complete the requested transfer.
  * #TEALET_ERR_MEM can still be returned with FORCE when only main-stack
  * growth would allow progress, because main is never marked defunct.
  *
- * #TEALET_EXIT_PANIC requests panic delivery to the receiving tealet as
+ * #TEALET_XFER_PANIC requests panic delivery to the receiving tealet as
  * #TEALET_ERR_PANIC on its resumed switch return path. It is invalid with
  * #TEALET_EXIT_DEFER (debug builds assert this flag combination).
  *
- * #TEALET_EXIT_NOFAIL enables automatic retry policy:
- * 1) requested target with #TEALET_EXIT_FORCE,
+ * #TEALET_XFER_NOFAIL enables automatic retry policy:
+ * 1) requested target with #TEALET_XFER_FORCE,
  * 2) panic+force fallback to main only on #TEALET_ERR_MEM/
  *    #TEALET_ERR_DEFUNCT. Other errors are returned unchanged.
- * When @p target is main, #TEALET_EXIT_NOFAIL is guaranteed to succeed,
+ * When @p target is main, #TEALET_XFER_NOFAIL is guaranteed to succeed,
  * because main is never allowed to become defunct.
  *
  * `return p;` from run() uses an implicit policy rooted in
- * `tealet_exit(p, NULL, TEALET_EXIT_DEFAULT)`, with retries for memory/defunct
+ * `tealet_exit(p, NULL, TEALET_XFER_DEFAULT)`, with retries for memory/defunct
  * failures and a panic+force fallback to main.
  */
 TEALET_API
@@ -454,7 +450,7 @@ tealet_t *tealet_duplicate(tealet_t *tealet);
  * @param target Tealet to delete.
  *
  * Deallocate a tealet.  Use this to delete a tealet that has exited
- * with tealet_exit() with 'TEALET_EXIT_DEFAULT', or defunct tealets.
+ * with tealet_exit() with 'TEALET_XFER_DEFAULT', or defunct tealets.
  * Active tealet can also be
  * deleted, such as stubs that are no longer in use, but take care
  * because any local resources in such tealets won't be freed.

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -382,13 +382,13 @@ int tealet_switch(tealet_t *target, void **parg, int flags);
 
 /* Transfer flags shared by tealet_switch() and tealet_exit() */
 #define TEALET_XFER_DEFAULT 0 /* default transfer behavior */
-#define TEALET_XFER_FORCE 4   /* force transfer despite save-time memory failures */
-#define TEALET_XFER_PANIC 8   /* mark the receiving tealet as panic-resumed */
-#define TEALET_XFER_NOFAIL 16 /* retry with FORCE and panic-to-main fallback */
+#define TEALET_XFER_FORCE 1   /* force transfer despite save-time memory failures */
+#define TEALET_XFER_PANIC 2   /* mark the receiving tealet as panic-resumed */
+#define TEALET_XFER_NOFAIL 4  /* retry with FORCE and panic-to-main fallback */
 
 /* Exit-only flags */
-#define TEALET_EXIT_DELETE 1 /* Auto-delete on exit; pointers to exiting tealet become invalid */
-#define TEALET_EXIT_DEFER 2  /* Defer exit to return statement */
+#define TEALET_EXIT_DELETE 256 /* Auto-delete on exit; pointers to exiting tealet become invalid */
+#define TEALET_EXIT_DEFER 512  /* Defer exit to return statement */
 
 /**
  * @brief Exit current tealet and transfer control to @p target.

--- a/src/tealet_extras.c
+++ b/src/tealet_extras.c
@@ -110,7 +110,7 @@ int tealet_stub_run(tealet_t *stub, tealet_run_t run, void **parg) {
   psarg->run = run;
   psarg->runarg = parg ? *parg : NULL;
   myarg = (void *)psarg;
-  result = tealet_switch(stub, &myarg, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(stub, &myarg, TEALET_XFER_DEFAULT);
   if (result) {
     /* failure */
     tealet_free(stub, psarg);

--- a/tests/setcontext.c
+++ b/tests/setcontext.c
@@ -29,12 +29,12 @@ tealet_t *loop_func(tealet_t *current, void *arg) {
     void *value = (void *)(intptr_t)i;
 
     /* Switch to main tealet */
-    tealet_switch(tealet_previous(current), &value, TEALET_SWITCH_DEFAULT);
+    tealet_switch(tealet_previous(current), &value, TEALET_XFER_DEFAULT);
     tealet_test_lock_assert_unheld(&g_lock_state);
     /* after switch, any void* passed _to_ us is in 'value' */
   }
   /* exit, without deleting, so that the caller can query status */
-  tealet_exit(tealet_previous(current), NULL, TEALET_EXIT_DEFAULT);
+  tealet_exit(tealet_previous(current), NULL, TEALET_XFER_DEFAULT);
   return 0; /* not reached */
 }
 
@@ -79,7 +79,7 @@ int main(void) {
      * only retrieve the result
      */
     printf("%d\n", (int)(intptr_t)data);
-    tealet_switch(loop, &data, TEALET_SWITCH_DEFAULT);
+    tealet_switch(loop, &data, TEALET_XFER_DEFAULT);
   }
   tealet_delete(loop);
   tealet_test_lock_assert_balanced(&g_lock_state);

--- a/tests/test_chunks.c
+++ b/tests/test_chunks.c
@@ -43,7 +43,7 @@ static tealet_t *worker_run(tealet_t *t, void *arg) {
     consume_stack(depth, buffer);
 
   /* Yield back to main */
-  tealet_switch(g_main, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(g_main, NULL, TEALET_XFER_DEFAULT);
 
   tealet_test_lock_assert_unheld(&g_lock_state);
 
@@ -90,9 +90,9 @@ int main(void) {
   }
 
   /* Switch to it a few times to build up stack */
-  tealet_switch(t1, NULL, TEALET_SWITCH_DEFAULT);
-  tealet_switch(t1, NULL, TEALET_SWITCH_DEFAULT);
-  tealet_switch(t1, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(t1, NULL, TEALET_XFER_DEFAULT);
+  tealet_switch(t1, NULL, TEALET_XFER_DEFAULT);
+  tealet_switch(t1, NULL, TEALET_XFER_DEFAULT);
 
   /* Now t1 has a saved stack with multiple chunks */
   tealet_get_stats(g_main, &stats);

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -139,13 +139,13 @@ static tealet_t *run_write_to_target(tealet_t *current, void *arg) {
   original = *target;
   *target ^= 0x5Au;
 
-  switch_result = tealet_switch(command->return_to, NULL, TEALET_SWITCH_DEFAULT);
+  switch_result = tealet_switch(command->return_to, NULL, TEALET_XFER_DEFAULT);
   if (command->first_switch_result)
     *command->first_switch_result = switch_result;
 
   if (switch_result == TEALET_ERR_INTEGRITY) {
     *target = original;
-    switch_result = tealet_switch(command->return_to, NULL, TEALET_SWITCH_DEFAULT);
+    switch_result = tealet_switch(command->return_to, NULL, TEALET_XFER_DEFAULT);
   }
 
   if (command->recovery_switch_result)
@@ -287,13 +287,13 @@ static tealet_t *run_write_with_mprotect_split(tealet_t *current, void *arg) {
   original = *target;
   *target ^= 0x5Au;
 
-  switch_result = tealet_switch(command->return_to, NULL, TEALET_SWITCH_DEFAULT);
+  switch_result = tealet_switch(command->return_to, NULL, TEALET_XFER_DEFAULT);
   if (command->first_switch_result)
     *command->first_switch_result = switch_result;
 
   if (switch_result == TEALET_ERR_INTEGRITY) {
     *target = original;
-    switch_result = tealet_switch(command->return_to, NULL, TEALET_SWITCH_DEFAULT);
+    switch_result = tealet_switch(command->return_to, NULL, TEALET_XFER_DEFAULT);
   }
 
   if (command->recovery_switch_result)
@@ -351,7 +351,7 @@ static int run_integrity_switch_case(int fail_policy, int write_inside, int *fir
   command->recovery_switch_result = &second_switch_result;
 
   arg = command;
-  result = tealet_switch(writer, &arg, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(writer, &arg, TEALET_XFER_DEFAULT);
   assert(result == 0);
   tealet_free(main_tealet, outside_target);
   tealet_free(main_tealet, command);
@@ -417,7 +417,7 @@ static int run_mprotect_split_case(int write_guard_page, int *first_result, int 
   command->recovery_switch_result = &second_switch_result;
 
   arg = command;
-  result = tealet_switch(writer, &arg, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(writer, &arg, TEALET_XFER_DEFAULT);
   if (write_guard_page) {
     if (first_result)
       *first_result = first_switch_result;
@@ -615,7 +615,7 @@ static void test_set_while_snapshot_active_resizes(void) {
   assert(worker != NULL);
 
   arg = command;
-  result = tealet_switch(worker, &arg, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(worker, &arg, TEALET_XFER_DEFAULT);
   assert(result == 0);
   assert(command->configure_result == 0);
 

--- a/tests/test_fork.c
+++ b/tests/test_fork.c
@@ -88,7 +88,7 @@ static void test_basic_fork(void *far_marker) {
     printf("  Parent: switching to child...\n");
 
     /* Switch to child */
-    result = tealet_switch(other, NULL, TEALET_SWITCH_DEFAULT);
+    result = tealet_switch(other, NULL, TEALET_XFER_DEFAULT);
     assert(result == 0);
     assert(testvalue == 0); /* Parent value should be preserved after child modifies it */
 
@@ -253,13 +253,13 @@ static void test_multiple_forks(void *far_marker) {
   /* Switch to child1 */
   visited++;
   printf("  Parent: switching to child1 (visited=%d)\n", visited);
-  tealet_switch(child1, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(child1, NULL, TEALET_XFER_DEFAULT);
   printf("  Parent: returned from child1\n");
 
   /* Switch to child2 */
   visited++;
   printf("  Parent: switching to child2 (visited=%d)\n", visited);
-  tealet_switch(child2, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(child2, NULL, TEALET_XFER_DEFAULT);
   printf("  Parent: returned from child2\n");
 
   assert(visited == 2);
@@ -305,7 +305,7 @@ static void test_fork_switch_arg(void *far_marker) {
     /* Switch back to parent with a value */
     childarg = (void *)0x12345678;
     printf("  Child: started.switching back with value %p\n", childarg);
-    tealet_switch(other, &childarg, TEALET_SWITCH_DEFAULT);
+    tealet_switch(other, &childarg, TEALET_XFER_DEFAULT);
     /* parent switched back, arg should be updated */
     assert(childarg == (void *)0xdeadbeef);
     printf("  Child: switched back from parent with arg=%p\n", childarg);
@@ -326,7 +326,7 @@ static void test_fork_switch_arg(void *far_marker) {
     parentarg = (void *)0xdeadbeef;
     /* switch back to child with a different arg, for the child to exit*/
     printf("  Parent: switching back to child with arg=%p\n", parentarg);
-    result = tealet_switch(other, &parentarg, TEALET_SWITCH_DEFAULT);
+    result = tealet_switch(other, &parentarg, TEALET_XFER_DEFAULT);
     printf("  Parent: returned from child switch, arg=%p, result=%d\n", parentarg, result);
     /* child should have exited, and passed the final arg to us*/
     assert(result == 0);
@@ -372,7 +372,7 @@ static void test_fork_default_arg(void *far_marker) {
 
     /* Switch to child with a value */
     parentarg = (void *)0xABCDEF00;
-    result = tealet_switch(child, &parentarg, TEALET_SWITCH_DEFAULT);
+    result = tealet_switch(child, &parentarg, TEALET_XFER_DEFAULT);
     assert(result == 0);
 
     /* Child should have switched back with a different value */
@@ -395,7 +395,7 @@ static void test_fork_default_arg(void *far_marker) {
 
     /* Switch back to parent with a different value */
     childarg = (void *)0xDEADBEEF;
-    tealet_switch(child, &childarg, TEALET_SWITCH_DEFAULT); /* child pointer is parent from child's perspective */
+    tealet_switch(child, &childarg, TEALET_XFER_DEFAULT); /* child pointer is parent from child's perspective */
 
     printf("  Child: this should never print\n");
     assert(0);
@@ -443,7 +443,7 @@ static void test_ping_pong(void *far_marker) {
 
     /* Ping-pong a few times */
     while (counter <= 5) {
-      tealet_switch(child_saved, NULL, TEALET_SWITCH_DEFAULT);
+      tealet_switch(child_saved, NULL, TEALET_XFER_DEFAULT);
       counter++;
       /* Parent increments by 1 each iteration (but only first 4) */
       if (counter <= 5) {
@@ -475,7 +475,7 @@ static void test_ping_pong(void *far_marker) {
       /* Child increments by 10 each iteration (counter goes 1,2,3,4 -> indices
        * 0,1,2,3) */
       data[counter - 1] += 10;
-      tealet_switch(child, NULL, TEALET_SWITCH_DEFAULT); /* child pointer is parent from child's perspective */
+      tealet_switch(child, NULL, TEALET_XFER_DEFAULT); /* child pointer is parent from child's perspective */
       counter++;
       printf("  Child: counter=%d, data=[%d,%d,%d,%d,%d], switching to parent\n", counter, data[0], data[1], data[2],
              data[3], data[4]);

--- a/tests/test_stochastic.c
+++ b/tests/test_stochastic.c
@@ -151,7 +151,7 @@ static int worker_recursive(tealet_t *current, int depth) {
       } else {
         /* Immediate exit: child tealets switch to main, main unwinds */
         if (current != g_main) {
-          tealet_switch(g_main, NULL, TEALET_SWITCH_DEFAULT);
+          tealet_switch(g_main, NULL, TEALET_XFER_DEFAULT);
           /* we should not resume this */
           assert(0);
         }
@@ -178,7 +178,7 @@ static int worker_recursive(tealet_t *current, int depth) {
       /* Switch to another tealet */
       target = pick_random_tealet(current);
       if (target) {
-        tealet_switch(target, NULL, TEALET_SWITCH_DEFAULT);
+        tealet_switch(target, NULL, TEALET_XFER_DEFAULT);
       }
       continue;
 
@@ -211,7 +211,7 @@ static int worker_recursive(tealet_t *current, int depth) {
         /* Switch to a random tealet */
         target = pick_random_tealet(current);
         if (target) {
-          tealet_switch(target, NULL, TEALET_SWITCH_DEFAULT);
+          tealet_switch(target, NULL, TEALET_XFER_DEFAULT);
         }
         /* We shouldn't resume here - we've exited */
         assert(0);
@@ -270,7 +270,7 @@ static tealet_t *worker_entry(tealet_t *current, void *arg) {
 
   /* When we return here normally, we're done - exit to main without auto-delete
    */
-  tealet_exit(g_main, NULL, TEALET_EXIT_DEFAULT);
+  tealet_exit(g_main, NULL, TEALET_XFER_DEFAULT);
 
   /* Unreachable */
   return g_main;
@@ -355,7 +355,7 @@ int main(int argc, char *argv[]) {
           if (g_verbose) {
             printf("  Switching to tealet %d to unwind\n", i);
           }
-          tealet_switch(g_tealets[i], NULL, TEALET_SWITCH_DEFAULT);
+          tealet_switch(g_tealets[i], NULL, TEALET_XFER_DEFAULT);
         }
       }
     }

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -239,7 +239,7 @@ static int tealet_new_x(tealet_t *m, tealet_t **out, tealet_run_t run, void **pa
   rc = tealet_spawn(m, &r, run, NULL, stack_far, TEALET_RUN_DEFAULT);
   if (rc != 0)
     return rc;
-  i = tealet_switch(r, parg, TEALET_SWITCH_DEFAULT);
+  i = tealet_switch(r, parg, TEALET_XFER_DEFAULT);
   if (i != 0) {
     tealet_delete(r);
     return i;
@@ -395,7 +395,7 @@ static tealet_t *test_stack_far_isolation_run(tealet_t *current, void *arg) {
   assert(current != run_arg->main);
   assert(run_arg->shared->value == run_arg->before);
   run_arg->shared->value = run_arg->after;
-  tealet_switch(run_arg->main, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(run_arg->main, NULL, TEALET_XFER_DEFAULT);
   assert(run_arg->shared->value == run_arg->after);
   return run_arg->main;
 }
@@ -427,7 +427,7 @@ static tealet_t *test_stack_far_isolation_parent(tealet_t *current, void *arg) {
   assert(shared.value == 11);
 
   /* Resume child: it confirms its private value, then returns/exits to parent. */
-  tealet_switch(child, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(child, NULL, TEALET_XFER_DEFAULT);
 
   /* Child has exited; explicit delete is still required. */
   tealet_delete(child);
@@ -493,7 +493,7 @@ void test_add_unbound_phase1(void) {
   assert(tealet_status(copy) == TEALET_STATUS_NEW);
   assert(tealet_get_far(copy) == NULL);
 
-  rc = tealet_switch(unbound, NULL, TEALET_SWITCH_DEFAULT);
+  rc = tealet_switch(unbound, NULL, TEALET_XFER_DEFAULT);
   assert(rc == TEALET_ERR_INVAL);
 
   tealet_delete(copy);
@@ -559,7 +559,7 @@ static tealet_t *test_lock_transition_run(tealet_t *current, void *arg) {
   lock_snapshot_assert_delta_one(&g_lock_new_before);
 
   g_lock_phase = LOCK_PHASE_WAIT_RESUME;
-  tealet_switch(g_main, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(g_main, NULL, TEALET_XFER_DEFAULT);
 
   tealet_test_lock_assert_unheld(&g_lock_state);
   assert(g_lock_phase == LOCK_PHASE_SWITCH_RESUME);
@@ -587,7 +587,7 @@ void test_lock_transitions(void) {
 
   lock_snapshot_take(&g_lock_switch_before);
   g_lock_phase = LOCK_PHASE_SWITCH_RESUME;
-  result = tealet_switch(t, NULL, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(t, NULL, TEALET_XFER_DEFAULT);
   assert(result == 0);
   assert(g_lock_phase == LOCK_PHASE_DONE);
 
@@ -682,7 +682,7 @@ void test_simple_create_and_run(void) {
   init_test();
   t = NULL;
   assert(tealet_spawn(g_main, &t, test_simple_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
-  tealet_switch(t, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(t, NULL, TEALET_XFER_DEFAULT);
   assert(status == 1);
   assert(tealet_previous(g_main) == t);
   tealet_delete(t);
@@ -707,7 +707,7 @@ void test_create_previous(void) {
   assert(tealet_spawn(g_main, &t, test_create_previous_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
   assert(status == 0);
   /* Now switch to it - it should see main as previous */
-  tealet_switch(t, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(t, NULL, TEALET_XFER_DEFAULT);
   assert(status == 42); /* Verify it ran */
   assert(tealet_previous(g_main) == t);
   tealet_delete(t);
@@ -717,7 +717,7 @@ void test_create_previous(void) {
 
 static tealet_t *test_previous_manual_delete_run(tealet_t *t1, void *arg) {
   (void)arg;
-  tealet_switch(t1->main, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(t1->main, NULL, TEALET_XFER_DEFAULT);
   return t1->main;
 }
 
@@ -729,7 +729,7 @@ void test_previous_cleared_on_manual_delete(void) {
   assert(tealet_spawn(g_main, &t, test_previous_manual_delete_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
   assert(t != NULL);
 
-  tealet_switch(t, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(t, NULL, TEALET_XFER_DEFAULT);
   assert(tealet_previous(g_main) == t);
 
   tealet_delete(t);
@@ -787,7 +787,7 @@ void test_exit(void) {
   assert(result == 0);
   assert(stub1 != NULL);
   stub2 = tealet_duplicate(stub1);
-  arg = (void *)TEALET_EXIT_DEFAULT;
+  arg = (void *)TEALET_XFER_DEFAULT;
   result = tealet_stub_run(stub1, test_exit_run, &arg);
   assert(result == 0);
   assert(status == 1);
@@ -811,16 +811,16 @@ tealet_t *test_switch_2(tealet_t *t2, void *arg) {
   assert(status == 1);
   status = 2;
   assert(tealet_current(g_main) == t2);
-  tealet_switch(glob_t1, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(glob_t1, NULL, TEALET_XFER_DEFAULT);
   assert(status == 3);
   status = 4;
   assert(tealet_current(g_main) == t2);
-  tealet_switch(glob_t1, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(glob_t1, NULL, TEALET_XFER_DEFAULT);
   assert(status == 5);
   status = 6;
   assert(t2 == glob_t2);
   assert(tealet_current(g_main) == t2);
-  tealet_switch(t2, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(t2, NULL, TEALET_XFER_DEFAULT);
   assert(status == 6);
   status = 7;
   assert(tealet_current(g_main) == t2);
@@ -837,7 +837,7 @@ tealet_t *test_switch_1(tealet_t *t1, void *arg) {
   assert(status == 2);
   status = 3;
   assert(tealet_current(g_main) == t1);
-  tealet_switch(glob_t2, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(glob_t2, NULL, TEALET_XFER_DEFAULT);
   assert(status == 4);
   status = 5;
   assert(tealet_current(g_main) == t1);
@@ -863,7 +863,7 @@ void test_switch_self_panic(void) {
   init_test();
 
   /* Self-switch with PANIC should consume panic immediately. */
-  result = tealet_switch(g_main, NULL, TEALET_SWITCH_PANIC);
+  result = tealet_switch(g_main, NULL, TEALET_XFER_PANIC);
   assert(result == TEALET_ERR_PANIC);
 
   /* Ensure panic flag is not left armed for a later unrelated switch. */
@@ -884,7 +884,7 @@ tealet_t *test_switch_new_1(tealet_t *t1, void *arg) {
   tealet_t *stub;
   int result;
   /* switch back to the creator */
-  tealet_switch(caller, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(caller, NULL, TEALET_XFER_DEFAULT);
   /* now we want to trample the stack */
   stub = NULL;
   result = tealet_new_descend(t1, &stub, 50, NULL, NULL, NULL);
@@ -899,7 +899,7 @@ tealet_t *test_switch_new_2(tealet_t *t2, void *arg) {
   tealet_t *target = (tealet_t *)arg;
   /* switch to tealet 1 to trample the stack*/
   target->extra = (void *)t2;
-  tealet_switch(target, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(target, NULL, TEALET_XFER_DEFAULT);
 
   /* and then return to main */
   return g_main;
@@ -919,7 +919,7 @@ void test_switch_new(void) {
   assert(result == 0);
   assert(tealet2 != NULL);
   assert(tealet_status(tealet2) == TEALET_STATUS_ACTIVE);
-  tealet_switch(tealet2, NULL, TEALET_SWITCH_DEFAULT);
+  tealet_switch(tealet2, NULL, TEALET_XFER_DEFAULT);
   tealet_delete(tealet1);
   tealet_delete(tealet2);
   fini_test();
@@ -932,7 +932,7 @@ tealet_t *test_arg_1(tealet_t *t1, void *arg) {
   void *myarg;
   tealet_t *peer = (tealet_t *)arg;
   myarg = (void *)1;
-  tealet_switch(peer, &myarg, TEALET_SWITCH_DEFAULT);
+  tealet_switch(peer, &myarg, TEALET_XFER_DEFAULT);
   assert(myarg == (void *)2);
   myarg = (void *)3;
   tealet_exit(peer, myarg, TEALET_EXIT_DELETE);
@@ -947,7 +947,7 @@ void test_arg(void) {
   t1 = tealet_new_native_call(g_main, test_arg_1, &myarg, NULL);
   assert(myarg == (void *)1);
   myarg = (void *)2;
-  tealet_switch(t1, &myarg, TEALET_SWITCH_DEFAULT);
+  tealet_switch(t1, &myarg, TEALET_XFER_DEFAULT);
   assert(myarg == (void *)3);
   fini_test();
 }
@@ -985,7 +985,7 @@ static void random_run(int index) {
       arg = (void *)(intptr_t)i;
       assert(tealet_new_native_call(g_main, random_new_tealet, &arg, NULL) != NULL);
     } else {
-      tealet_switch(tealetarray[i], NULL, TEALET_SWITCH_DEFAULT);
+      tealet_switch(tealetarray[i], NULL, TEALET_XFER_DEFAULT);
     }
     assert(status >= prevstatus);
     assert(tealet_current(g_main) == cur);
@@ -1076,7 +1076,7 @@ int random2_descend(int index, int level) {
     if (tealetarray[target] == NULL)
       random2_new(target);
     else
-      tealet_switch(tealetarray[target], NULL, TEALET_SWITCH_DEFAULT);
+      tealet_switch(tealetarray[target], NULL, TEALET_XFER_DEFAULT);
     return 1;
   } else {
     /* find a telet */
@@ -1085,7 +1085,7 @@ int random2_descend(int index, int level) {
       int k = (j + target) % ARRAYSIZE;
       if (k != index && tealetarray[k]) {
         status += 1;
-        tealet_switch(tealetarray[k], NULL, TEALET_SWITCH_DEFAULT);
+        tealet_switch(tealetarray[k], NULL, TEALET_XFER_DEFAULT);
         return 1;
       }
     }
@@ -1124,7 +1124,7 @@ void test_random2(void) {
     for (i = 1; i < ARRAYSIZE; i++)
       if (tealetarray[i]) {
         status++;
-        tealet_switch(tealetarray[i], NULL, TEALET_SWITCH_DEFAULT);
+        tealet_switch(tealetarray[i], NULL, TEALET_XFER_DEFAULT);
         break;
       }
     if (i == ARRAYSIZE)
@@ -1219,7 +1219,7 @@ tealet_t *mem_error_tealet(tealet_t *t1, void *arg) {
   int res;
   tealet_t *peer = (tealet_t *)arg;
   talloc_fail = 1;
-  res = tealet_switch(peer, &myarg, TEALET_SWITCH_DEFAULT);
+  res = tealet_switch(peer, &myarg, TEALET_XFER_DEFAULT);
   assert(res == TEALET_ERR_MEM);
   tealet_exit(peer, myarg, TEALET_EXIT_DELETE);
   abort(); // never runs
@@ -1243,11 +1243,11 @@ static tealet_t *oom_force_to_main_run(tealet_t *current, void *arg) {
 
   /* First attempt without FORCE fails in-place with MEM. */
   talloc_fail = 1;
-  result = tealet_switch(current->main, NULL, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(current->main, NULL, TEALET_XFER_DEFAULT);
   assert(result == TEALET_ERR_MEM);
 
   /* FORCE should continue by defuncting current and transferring out. */
-  result = tealet_switch(current->main, NULL, TEALET_SWITCH_FORCE);
+  result = tealet_switch(current->main, NULL, TEALET_XFER_FORCE);
   abort();
   assert(result == 0);
   return NULL;
@@ -1266,12 +1266,12 @@ void test_oom_force_marks_source_defunct(void) {
   assert(tealet_spawn(g_main, &worker, oom_force_to_main_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
   assert(worker != NULL);
 
-  result = tealet_switch(worker, NULL, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(worker, NULL, TEALET_XFER_DEFAULT);
   assert(result == 0);
 
   talloc_fail = 0;
   assert(tealet_status(worker) == TEALET_STATUS_DEFUNCT);
-  result = tealet_switch(worker, NULL, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(worker, NULL, TEALET_XFER_DEFAULT);
   assert(result == TEALET_ERR_DEFUNCT);
 
   tealet_delete(worker);
@@ -1297,7 +1297,7 @@ void test_oom_force_main_not_defunct(void) {
   assert(worker != NULL);
 
   talloc_fail = 1;
-  result = tealet_switch(worker, NULL, TEALET_SWITCH_FORCE);
+  result = tealet_switch(worker, NULL, TEALET_XFER_FORCE);
   assert(result == TEALET_ERR_MEM);
 
   talloc_fail = 0;
@@ -1316,7 +1316,7 @@ static tealet_t *oom_force_peer_to_main_panic_run(tealet_t *current, void *arg) 
 
   /* Clear allocator fault so this switch-out can complete. */
   talloc_fail = 0;
-  result = tealet_switch(current->main, NULL, TEALET_SWITCH_PANIC);
+  result = tealet_switch(current->main, NULL, TEALET_XFER_PANIC);
   abort();
   assert(result == TEALET_ERR_PANIC);
   return NULL;
@@ -1329,7 +1329,7 @@ static tealet_t *oom_force_to_peer_run(tealet_t *current, void *arg) {
   assert(oom_w2 != NULL);
 
   talloc_fail = 1;
-  result = tealet_switch(oom_w2, NULL, TEALET_SWITCH_FORCE);
+  result = tealet_switch(oom_w2, NULL, TEALET_XFER_FORCE);
   abort();
   assert(result == 0);
   (void)current;
@@ -1354,11 +1354,11 @@ void test_oom_force_peer_then_panic_main(void) {
   assert(tealet_spawn(g_main, &w1, oom_force_to_peer_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
   assert(w1 != NULL);
 
-  result = tealet_switch(w1, NULL, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(w1, NULL, TEALET_XFER_DEFAULT);
   assert(result == TEALET_ERR_PANIC);
 
   assert(tealet_status(w1) == TEALET_STATUS_DEFUNCT);
-  result = tealet_switch(w1, NULL, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(w1, NULL, TEALET_XFER_DEFAULT);
   assert(result == TEALET_ERR_DEFUNCT);
 
   tealet_delete(w1);
@@ -1373,7 +1373,7 @@ static tealet_t *switch_nofail_mem_run(tealet_t *current, void *arg) {
 
   /* Purpose: NOFAIL should retry with FORCE and transfer to main under OOM. */
   talloc_fail = 1;
-  tealet_switch(current->main, NULL, TEALET_SWITCH_NOFAIL);
+  tealet_switch(current->main, NULL, TEALET_XFER_NOFAIL);
   abort();
   return NULL;
 }
@@ -1388,7 +1388,7 @@ void test_switch_nofail_retries_force(void) {
   assert(tealet_spawn(g_main, &worker, switch_nofail_mem_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
   assert(worker != NULL);
 
-  result = tealet_switch(worker, NULL, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(worker, NULL, TEALET_XFER_DEFAULT);
   assert(result == 0);
 
   talloc_fail = 0;
@@ -1400,7 +1400,7 @@ void test_switch_nofail_retries_force(void) {
 static tealet_t *switch_nofail_defunct_target_run(tealet_t *current, void *arg) {
   tealet_t *target = (tealet_t *)arg;
 
-  tealet_switch(target, NULL, TEALET_SWITCH_NOFAIL);
+  tealet_switch(target, NULL, TEALET_XFER_NOFAIL);
   abort();
   (void)current;
   return NULL;
@@ -1418,7 +1418,7 @@ void test_switch_nofail_defunct_target_panics_main(void) {
   assert(tealet_spawn(g_main, &victim, oom_force_to_main_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
   assert(victim != NULL);
 
-  result = tealet_switch(victim, NULL, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(victim, NULL, TEALET_XFER_DEFAULT);
   assert(result == 0);
   talloc_fail = 0;
   assert(tealet_status(victim) == TEALET_STATUS_DEFUNCT);
@@ -1427,7 +1427,7 @@ void test_switch_nofail_defunct_target_panics_main(void) {
   assert(tealet_spawn(g_main, &switcher, switch_nofail_defunct_target_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
   assert(switcher != NULL);
   arg = (void *)victim;
-  result = tealet_switch(switcher, &arg, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(switcher, &arg, TEALET_XFER_DEFAULT);
   assert(result == TEALET_ERR_PANIC);
 
   tealet_delete(switcher);
@@ -1440,7 +1440,7 @@ static tealet_t *exit_nofail_mem_run(tealet_t *current, void *arg) {
 
   /* Purpose: NOFAIL should retry with FORCE and transfer to main under OOM. */
   talloc_fail = 1;
-  tealet_exit(current->main, NULL, TEALET_EXIT_NOFAIL);
+  tealet_exit(current->main, NULL, TEALET_XFER_NOFAIL);
   abort();
   return NULL;
 }
@@ -1455,7 +1455,7 @@ void test_exit_nofail_retries_force(void) {
   assert(tealet_spawn(g_main, &worker, exit_nofail_mem_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
   assert(worker != NULL);
 
-  result = tealet_switch(worker, NULL, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(worker, NULL, TEALET_XFER_DEFAULT);
   assert(result == 0);
 
   talloc_fail = 0;
@@ -1467,7 +1467,7 @@ void test_exit_nofail_retries_force(void) {
 static tealet_t *exit_nofail_defunct_target_run(tealet_t *current, void *arg) {
   tealet_t *target = (tealet_t *)arg;
 
-  tealet_exit(target, NULL, TEALET_EXIT_NOFAIL);
+  tealet_exit(target, NULL, TEALET_XFER_NOFAIL);
   abort();
   (void)current;
   return NULL;
@@ -1485,7 +1485,7 @@ void test_exit_nofail_defunct_target_panics_main(void) {
   assert(tealet_spawn(g_main, &victim, oom_force_to_main_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
   assert(victim != NULL);
 
-  result = tealet_switch(victim, NULL, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(victim, NULL, TEALET_XFER_DEFAULT);
   assert(result == 0);
   talloc_fail = 0;
   assert(tealet_status(victim) == TEALET_STATUS_DEFUNCT);
@@ -1494,7 +1494,7 @@ void test_exit_nofail_defunct_target_panics_main(void) {
   assert(tealet_spawn(g_main, &exiter, exit_nofail_defunct_target_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
   assert(exiter != NULL);
   arg = (void *)victim;
-  result = tealet_switch(exiter, &arg, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(exiter, &arg, TEALET_XFER_DEFAULT);
   assert(result == TEALET_ERR_PANIC);
 
   tealet_delete(exiter);
@@ -1525,7 +1525,7 @@ void test_exit_self_invalid(void) {
   runner = NULL;
   assert(tealet_spawn(g_main, &runner, test_exit_self_invalid_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
   assert(runner != NULL);
-  assert(tealet_switch(runner, NULL, TEALET_SWITCH_DEFAULT) == 0);
+  assert(tealet_switch(runner, NULL, TEALET_XFER_DEFAULT) == 0);
 
   fini_test();
 }
@@ -1563,7 +1563,7 @@ void test_exit_defunct_target_returns_error(void) {
   assert(tealet_spawn(g_main, &exiter, test_exit_defunct_fail_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
   assert(exiter != NULL);
   arg = (void *)victim;
-  result = tealet_switch(exiter, &arg, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(exiter, &arg, TEALET_XFER_DEFAULT);
   assert(result == 0);
 
   tealet_delete(victim);
@@ -1574,7 +1574,7 @@ static tealet_t *test_explicit_panic_exit_run(tealet_t *current, void *arg) {
   tealet_t *target = (tealet_t *)arg;
 
   assert(current != g_main);
-  tealet_exit(target, NULL, TEALET_EXIT_DELETE | TEALET_EXIT_PANIC);
+  tealet_exit(target, NULL, TEALET_EXIT_DELETE | TEALET_XFER_PANIC);
   abort();
   return NULL;
 }
@@ -1590,7 +1590,7 @@ void test_exit_explicit_panic(void) {
   assert(tealet_spawn(g_main, &exiter, test_explicit_panic_exit_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
   assert(exiter != NULL);
   arg = (void *)g_main;
-  result = tealet_switch(exiter, &arg, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(exiter, &arg, TEALET_XFER_DEFAULT);
   assert(result == TEALET_ERR_PANIC);
 
   fini_test();
@@ -1618,7 +1618,7 @@ void test_debug_swap_far_invalid_caller_check_main(void) {
   result = tealet_debug_swap_far(g_main, new_far, &old_far);
   assert(result == 0);
 
-  result = tealet_switch(child, NULL, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(child, NULL, TEALET_XFER_DEFAULT);
   assert(result == TEALET_ERR_INVAL);
 
   result = tealet_debug_swap_far(g_main, old_far, &old_far);
@@ -1643,7 +1643,7 @@ static tealet_t *test_invalid_caller_check_child_run(tealet_t *current, void *ar
   result = tealet_debug_swap_far(current, new_far, &old_far);
   assert(result == 0);
 
-  result = tealet_switch(g_main, NULL, TEALET_SWITCH_DEFAULT);
+  result = tealet_switch(g_main, NULL, TEALET_XFER_DEFAULT);
   assert(result == TEALET_ERR_INVAL);
 
   result = tealet_debug_swap_far(current, old_far, &old_far);


### PR DESCRIPTION
## Summary
- migrate public switch/exit transfer flags to shared `TEALET_XFER_*` API names
- renumber transfer/exit-only flag bit ranges to keep transfer flags in low bits and exit-only flags separate
- refactor common switch/exit transfer mechanics into shared internal helper (`tealet_xfer_inner`)
- clarify one-shot internal transfer signaling lifecycle (`SAVEFORCE`, `PANIC`) and centralize consumption/clearing in transfer machinery
- add compiler-generated header dependency tracking in build rules
- update docs/tests/changelog for the new transfer flag model and behavior

## Validation
- make test
