### PR TITLE
API cleanup: simplify fork and orthogonalize start modes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,13 +74,13 @@ tealet_finalize(main);
 ```c
 // Pattern 1: Create/bind then switch
 tealet_t *g = tealet_new(main);
-tealet_run(g, run_func, NULL, NULL, TEALET_RUN_DEFAULT);
+tealet_run(g, run_func, NULL, NULL, TEALET_START_DEFAULT);
 void *arg = my_data;
 tealet_switch(g, &arg, TEALET_XFER_DEFAULT);
 
 // Pattern 2: Create and switch atomically
 tealet_t *g = tealet_new(main);
-tealet_run(g, run_func, &arg, NULL, TEALET_RUN_SWITCH);
+tealet_run(g, run_func, &arg, NULL, TEALET_START_SWITCH);
 ```
 
 ### Run Function Pattern
@@ -332,7 +332,7 @@ Use this when you need to [specific use case].
 \`\`\`c
 // Practical example
 tealet_t *t = tealet_new(main);
-tealet_run(t, my_func, &arg, NULL, TEALET_RUN_SWITCH);
+tealet_run(t, my_func, &arg, NULL, TEALET_START_SWITCH);
 \`\`\`
 
 **Note:** Platform-specific behavior or limitations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     switch) are returned unchanged.
 
 ### Changed
+- **Fork and start-mode API cleanup for orthogonality**
+  - Simplified `tealet_fork()` by removing side out-parameter signaling and
+    documenting side detection via `tealet_current(child) == child`.
+  - Renamed shared start flags from `TEALET_RUN_*` to `TEALET_START_*` to
+    better reflect usage across `tealet_run()`, `tealet_fork()`, and
+    `tealet_spawn()`.
+  - Updated tests and public docs to use the simplified fork contract and the
+    `TEALET_START_*` flag family.
+
 - **Regression test suite was restructured into focused modules**
   - Split the former monolithic regression harness into dedicated test files
     (lifecycle, transfer, locking, resilience, stack, stats, and stress) with
@@ -56,10 +65,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Creation semantics now use explicit allocation + bind/start steps**
   - `tealet_new()` now allocates and returns a NEW/unbound tealet handle.
   - `tealet_run()` is the bind/start primitive, with:
-    - `TEALET_RUN_DEFAULT` for deferred start (capture without immediate switch)
-    - `TEALET_RUN_SWITCH` for immediate start via an optimized single path
-      equivalent in effect to `TEALET_RUN_DEFAULT` + `tealet_switch()`.
-  - `tealet_fork()` now uses `TEALET_RUN_DEFAULT` / `TEALET_RUN_SWITCH`
+    - `TEALET_START_DEFAULT` for deferred start (capture without immediate switch)
+    - `TEALET_START_SWITCH` for immediate start via an optimized single path
+      equivalent in effect to `TEALET_START_DEFAULT` + `tealet_switch()`.
+  - `tealet_fork()` now uses `TEALET_START_DEFAULT` / `TEALET_START_SWITCH`
     mode flags.
 
 - **Public transfer flags were renamed to `TEALET_XFER_*`**
@@ -88,7 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed core `tealet_create()` and the old create-and-start `tealet_new(...)`
     out-parameter signature.
   - Removed legacy `TEALET_FORK_DEFAULT` / `TEALET_FORK_SWITCH` flags in favor
-    of `TEALET_RUN_*`.
+    of `TEALET_START_*`.
 
 - **Separate switch/exit transfer-flag names removed**
   - Removed `TEALET_SWITCH_DEFAULT` / `TEALET_SWITCH_FORCE` /
@@ -99,7 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 - Updated `README.md`, `docs/GETTING_STARTED.md`, `docs/API.md`,
   `docs/ARCHITECTURE.md`, and `src/tealet.h` Doxygen comments to reflect the
-  new creation flow and run-mode semantics.
+  new creation flow and start-mode semantics.
 
 ## [0.6.0] - 2026-05-09
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ int main(void) {
     
     void *arg = NULL;
     tealet_t *coro = tealet_new(main);
-    tealet_run(coro, worker, &arg, NULL, TEALET_RUN_SWITCH);
+    tealet_run(coro, worker, &arg, NULL, TEALET_START_SWITCH);
     tealet_delete(coro);
     
     tealet_finalize(main);

--- a/docs/API.md
+++ b/docs/API.md
@@ -222,7 +222,7 @@ Set a stack boundary on a tealet, limiting how far its stack can extend.
 
 **Returns:**
 - `0` on success
-- `-1` if called from non-main tealet or if tealet is not currently active
+- `TEALET_ERR_INVAL` if called on a non-main tealet
 
 **Best Practice - Use Parent Function's Stack Variable:**
 
@@ -1037,7 +1037,7 @@ tealet_delete(t);
 - Only call on tealets that are still allocated
 
 **When to Use:**
-- Deleting tealets that never ran (`TEALET_STATUS_INITIAL`)
+- Deleting tealets that never ran (`TEALET_STATUS_NEW`)
 - Cleaning up tealets kept alive with `TEALET_XFER_DEFAULT`
 - Cleaning up tealets that returned normally
 - Manual resource management

--- a/docs/API.md
+++ b/docs/API.md
@@ -94,23 +94,23 @@ Bind an unbound tealet to a run function and initialize its initial saved stack 
 **Parameters:**
 - `tealet`: NEW/unbound target tealet (typically from `tealet_new()`)
 - `run`: Function to execute in the tealet context
-- `parg`: Optional in/out argument pointer used with `TEALET_RUN_SWITCH`
+- `parg`: Optional in/out argument pointer used with `TEALET_START_SWITCH`
 - `stack_far`: Optional far-boundary requirement for the initial stack snapshot (`NULL` uses default)
-- `flags`: `TEALET_RUN_DEFAULT` or `TEALET_RUN_SWITCH`
+- `flags`: `TEALET_START_DEFAULT` or `TEALET_START_SWITCH`
 
 **Returns:**
 - `0` on success
 - negative `TEALET_ERR_*` on failure
 
-`TEALET_RUN_DEFAULT` captures initial state and returns without switching. Start later with `tealet_switch()`.
+`TEALET_START_DEFAULT` captures initial state and returns without switching. Start later with `tealet_switch()`.
 
-`TEALET_RUN_SWITCH` captures state and immediately switches to the target tealet.
-Conceptually, this is equivalent to `TEALET_RUN_DEFAULT` followed by `tealet_switch()`, but implemented as a single optimized path that avoids redundant internal state transitions.
+`TEALET_START_SWITCH` captures state and immediately switches to the target tealet.
+Conceptually, this is equivalent to `TEALET_START_DEFAULT` followed by `tealet_switch()`, but implemented as a single optimized path that avoids redundant internal state transitions.
 
 **Usage (deferred start):**
 ```c
 tealet_t *t = tealet_new(main);
-tealet_run(t, my_run, NULL, NULL, TEALET_RUN_DEFAULT);
+tealet_run(t, my_run, NULL, NULL, TEALET_START_DEFAULT);
 
 void *arg = my_data;
 tealet_switch(t, &arg, TEALET_XFER_DEFAULT);
@@ -120,7 +120,7 @@ tealet_switch(t, &arg, TEALET_XFER_DEFAULT);
 ```c
 void *arg = my_data;
 tealet_t *t = tealet_new(main);
-tealet_run(t, my_run, &arg, NULL, TEALET_RUN_SWITCH);
+tealet_run(t, my_run, &arg, NULL, TEALET_START_SWITCH);
 ```
 
 ### Example: include additional caller stack data
@@ -151,7 +151,7 @@ void bar(tealet_t *main) {
     stack_far = tealet_stack_further(&local_state, &local_state + 1);
 
     worker = tealet_new(main);
-    tealet_run(worker, my_run, &arg, stack_far, TEALET_RUN_SWITCH);
+    tealet_run(worker, my_run, &arg, stack_far, TEALET_START_SWITCH);
     (void)worker;
 }
 ```
@@ -243,7 +243,7 @@ void run_program(void *far_marker) {
     tealet_set_far(main, far_marker);
     
     int local_data = 0;  /* This WILL be saved when forking */
-    tealet_fork(child, NULL, TEALET_RUN_DEFAULT);
+    tealet_fork(child, NULL, TEALET_START_DEFAULT);
     /* local_data and other locals are safely in the saved stack */
     
     tealet_finalize(main);
@@ -260,7 +260,7 @@ void my_main(void) {
     tealet_set_far(main, &far_marker);
     
     int local_data = 0;  /* Declared AFTER far_marker */
-    tealet_fork(child, NULL, TEALET_RUN_DEFAULT);
+    tealet_fork(child, NULL, TEALET_START_DEFAULT);
     /* local_data is safely below far_marker on stack */
 }
 ```
@@ -287,12 +287,12 @@ Fork the current tealet into a NEW child tealet, duplicating execution state.
 **Parameters:**
 - `child`: NEW/unbound tealet (from `tealet_new()`) that receives forked child state
 - `parg`: Pointer to argument pointer for passing values to the suspended side. Can be NULL if no argument passing is desired (similar to `tealet_run()` and `tealet_switch()`)
-        - With `TEALET_RUN_DEFAULT`: Parent continues, child is suspended. When parent switches to child, child receives value via `*parg`
-        - With `TEALET_RUN_SWITCH`: Child continues, parent is suspended. When child switches back, parent receives value via `*parg`
+        - With `TEALET_START_DEFAULT`: Parent continues, child is suspended. When parent switches to child, child receives value via `*parg`
+        - With `TEALET_START_SWITCH`: Child continues, parent is suspended. When child switches back, parent receives value via `*parg`
         - See `tealet_run()` for detailed argument passing semantics
 - `flags`: Fork mode flags:
-    - `TEALET_RUN_DEFAULT` (0): Child created suspended, parent continues
-    - `TEALET_RUN_SWITCH` (1): Immediately switch to child after creation
+    - `TEALET_START_DEFAULT` (0): Child created suspended, parent continues
+    - `TEALET_START_SWITCH` (1): Immediately switch to child after creation
 
 **Returns:**
 - `0` on success
@@ -316,7 +316,7 @@ int main(void) {
     tealet_t *child = tealet_new(main);
     int is_child;
     void *arg = NULL;
-    int result = tealet_fork(child, &arg, TEALET_RUN_DEFAULT);
+    int result = tealet_fork(child, &arg, TEALET_START_DEFAULT);
     is_child = (tealet_current(child) == child);
     
     if (result < 0) {
@@ -369,8 +369,8 @@ Traditional tealet creation (`tealet_new()` + `tealet_run()`) maintains clean fu
 This feature mirrors functionality from Stackless Python but was historically omitted from libtealet to keep the API simple and safe. Use it when you need advanced patterns like continuation capture or coroutine cloning.
 
 **Flags:**
-- `TEALET_RUN_DEFAULT`: Child suspended, parent continues (Unix fork-like)
-- `TEALET_RUN_SWITCH`: Immediately become the child, parent suspended
+- `TEALET_START_DEFAULT`: Child suspended, parent continues (Unix fork-like)
+- `TEALET_START_SWITCH`: Immediately become the child, parent suspended
 
 ---
 
@@ -1025,7 +1025,7 @@ Explicitly delete a tealet and free its resources.
 ```c
 tealet_t *t = NULL;
 t = tealet_new(main);
-if (tealet_run(t, my_run, NULL, NULL, TEALET_RUN_DEFAULT) != 0) {
+if (tealet_run(t, my_run, NULL, NULL, TEALET_START_DEFAULT) != 0) {
     /* Handle create failure */
 }
 /* Use t... */
@@ -1264,7 +1264,7 @@ Forced transfer note (`tealet_switch(..., TEALET_XFER_FORCE)` and
 
 For `tealet_run()`:
 - `TEALET_ERR_MEM` is the bind/start failure case.
-- `TEALET_ERR_PANIC` signals an unexpected panic-tagged switch-back during `TEALET_RUN_SWITCH` startup.
+- `TEALET_ERR_PANIC` signals an unexpected panic-tagged switch-back during `TEALET_START_SWITCH` startup.
 
 Practical note for switch/exit failures:
 - In non-main tealets, the usual recovery path is to perform local cleanup and then exit to `main`.
@@ -1299,7 +1299,7 @@ Memory allocation failed.
 **Example:**
 ```c
 tealet_t *t = tealet_new(main);
-if (tealet_run(t, my_run, NULL, NULL, TEALET_RUN_DEFAULT) != 0) {
+if (tealet_run(t, my_run, NULL, NULL, TEALET_START_DEFAULT) != 0) {
     fprintf(stderr, "Out of memory\n");
     return TEALET_ERR_MEM;
 }
@@ -1394,12 +1394,12 @@ Used with `tealet_switch()` and `tealet_exit()`.
 
 ### When to Use Deferred vs Immediate Start
 
-**Use `tealet_new()` + `tealet_run(..., TEALET_RUN_DEFAULT)`:**
+**Use `tealet_new()` + `tealet_run(..., TEALET_START_DEFAULT)`:**
 - Setting up multiple coroutines before starting any
 - Need to pass tealet pointer to other setup code
 - Separating creation from execution for clarity
 
-**Use `tealet_new()` + `tealet_run(..., TEALET_RUN_SWITCH)`:**
+**Use `tealet_new()` + `tealet_run(..., TEALET_START_SWITCH)`:**
 - Start execution immediately
 - Don't need the tealet pointer before it runs
 - More concise code
@@ -1409,8 +1409,8 @@ Used with `tealet_switch()` and `tealet_exit()`.
 /* Pattern 1: Deferred start (more control) */
 tealet_t *t1 = tealet_new(main);
 tealet_t *t2 = tealet_new(main);
-tealet_run(t1, func1, NULL, NULL, TEALET_RUN_DEFAULT);
-tealet_run(t2, func2, NULL, NULL, TEALET_RUN_DEFAULT);
+tealet_run(t1, func1, NULL, NULL, TEALET_START_DEFAULT);
+tealet_run(t2, func2, NULL, NULL, TEALET_START_DEFAULT);
 setup_relationship(t1, t2);  /* Both exist but not started */
 void *arg = t2;
 tealet_switch(t1, &arg, TEALET_XFER_DEFAULT);  /* Now start t1 */
@@ -1418,7 +1418,7 @@ tealet_switch(t1, &arg, TEALET_XFER_DEFAULT);  /* Now start t1 */
 /* Pattern 2: Immediate start (more concise) */
 void *arg = my_data;
 tealet_t *t = tealet_new(main);
-tealet_run(t, my_func, &arg, NULL, TEALET_RUN_SWITCH);
+tealet_run(t, my_func, &arg, NULL, TEALET_START_SWITCH);
 /* Already started, arg contains first return value */
 ```
 
@@ -1567,7 +1567,7 @@ int main(void) {
     
     /* Create counter tealet */
     tealet_t *counter = tealet_new(main);
-    if (tealet_run(counter, counter_run, NULL, NULL, TEALET_RUN_DEFAULT) != 0) {
+    if (tealet_run(counter, counter_run, NULL, NULL, TEALET_START_DEFAULT) != 0) {
         fprintf(stderr, "Failed to create counter\n");
         tealet_finalize(main);
         return 1;

--- a/docs/API.md
+++ b/docs/API.md
@@ -239,10 +239,11 @@ int main(void) {
 void run_program(void *far_marker) {
     tealet_alloc_t alloc = TEALET_ALLOC_INIT_MALLOC;
     tealet_t *main = tealet_initialize(&alloc, 0);
+    tealet_t *child = tealet_new(main);
     tealet_set_far(main, far_marker);
     
     int local_data = 0;  /* This WILL be saved when forking */
-    tealet_fork(main, &child, NULL, 0);
+    tealet_fork(child, NULL, TEALET_RUN_DEFAULT);
     /* local_data and other locals are safely in the saved stack */
     
     tealet_finalize(main);
@@ -255,10 +256,11 @@ void my_main(void) {
     int far_marker;  /* MUST be declared FIRST */
     tealet_alloc_t alloc = TEALET_ALLOC_INIT_MALLOC;
     tealet_t *main = tealet_initialize(&alloc, 0);
+    tealet_t *child = tealet_new(main);
     tealet_set_far(main, &far_marker);
     
     int local_data = 0;  /* Declared AFTER far_marker */
-    tealet_fork(main, &child, NULL, 0);
+    tealet_fork(child, NULL, TEALET_RUN_DEFAULT);
     /* local_data is safely below far_marker on stack */
 }
 ```
@@ -277,30 +279,29 @@ You can also obtain a call-site boundary marker with `tealet_new_probe()` when y
 ### tealet_fork()
 
 ```c
-int tealet_fork(tealet_t *child, tealet_t **pother, void **parg, int flags);
+int tealet_fork(tealet_t *child, void **parg, int flags);
 ```
 
 Fork the current tealet into a NEW child tealet, duplicating execution state.
 
 **Parameters:**
 - `child`: NEW/unbound tealet (from `tealet_new()`) that receives forked child state
-- `pother`: Pointer to receive the "other" tealet pointer:
-  - In parent: receives pointer to child
-  - In child: receives pointer to parent
 - `parg`: Pointer to argument pointer for passing values to the suspended side. Can be NULL if no argument passing is desired (similar to `tealet_run()` and `tealet_switch()`)
-    - With `TEALET_RUN_DEFAULT`: Parent continues, child is suspended. When parent switches to child, child receives value via `*parg`
-    - With `TEALET_RUN_SWITCH`: Child continues, parent is suspended. When child switches back, parent receives value via `*parg`
-    - See `tealet_run()` for detailed argument passing semantics
+        - With `TEALET_RUN_DEFAULT`: Parent continues, child is suspended. When parent switches to child, child receives value via `*parg`
+        - With `TEALET_RUN_SWITCH`: Child continues, parent is suspended. When child switches back, parent receives value via `*parg`
+        - See `tealet_run()` for detailed argument passing semantics
 - `flags`: Fork mode flags:
     - `TEALET_RUN_DEFAULT` (0): Child created suspended, parent continues
     - `TEALET_RUN_SWITCH` (1): Immediately switch to child after creation
 
 **Returns:**
-- Parent: `1` (default mode) - you are the parent
-- Child: `0` - you are the child  
+- `0` on success
 - Error: negative error code
   - `TEALET_ERR_UNFORKABLE`: Current tealet has unbounded stack (call `tealet_set_far()` first)
   - `TEALET_ERR_MEM`: Memory allocation failed
+
+Determine side after a successful call with:
+- `is_child = (tealet_current(child) == child)`
 
 **Usage:**
 ```c
@@ -313,35 +314,35 @@ int main(void) {
     tealet_set_far(main, &stack_marker);
     
     tealet_t *child = tealet_new(main);
-    tealet_t *other = NULL;
+    int is_child;
     void *arg = NULL;
-    int result = tealet_fork(child, &other, &arg, TEALET_RUN_DEFAULT);
+    int result = tealet_fork(child, &arg, TEALET_RUN_DEFAULT);
+    is_child = (tealet_current(child) == child);
     
-    if (result == 0) {
+    if (result < 0) {
+        fprintf(stderr, "Fork failed: %d\n", result);
+    } else if (is_child) {
         /* This is the CHILD */
-        printf("Child: parent is %p, received arg=%p\n", other, arg);
+        printf("Child: parent is %p, received arg=%p\n", main, arg);
         
         /* CRITICAL: Forked tealets MUST use tealet_exit() */
         void *return_value = (void*)0x1234;
-        tealet_exit(other, return_value, TEALET_XFER_NOFAIL);  /* Switch back to parent */
+        tealet_exit(main, return_value, TEALET_XFER_NOFAIL);  /* Switch back to parent */
         
         /* Should not reach here */
         abort();
         
-    } else if (result > 0) {
+    } else {
         /* This is the PARENT */
-        printf("Parent: child is %p\n", other);
+        printf("Parent: child is %p\n", child);
         
         /* Switch to child with an argument */
         arg = (void*)0x5678;
-        tealet_switch(other, &arg, TEALET_XFER_DEFAULT);
+        tealet_switch(child, &arg, TEALET_XFER_DEFAULT);
         printf("Parent: child returned with arg=%p\n", arg);
         
         /* Clean up */
-        tealet_delete(other);
-    } else {
-        /* Error occurred */
-        fprintf(stderr, "Fork failed: %d\n", result);
+        tealet_delete(child);
     }
     
     tealet_finalize(main);
@@ -359,6 +360,7 @@ int main(void) {
     - Forks of regular function-scoped tealets can generally return through the same run-function path as the original tealet.
 4. **No DEFER for main-lineage forks:** Do not use `TEALET_EXIT_DEFER` in that mode.
 5. **Stay within bounds:** All switching must occur within the stack region bounded by `far_boundary` where a boundary is in effect.
+6. **Finding the opposite side:** In main-lineage examples, child can usually target `main` directly. In generalized fork flows, use `tealet_previous(main)` at first resume to capture the opposite tealet.
 
 **Philosophical note:**
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -91,7 +91,7 @@ int main(void) {
     /* Create and run a coroutine */
     void *arg = "Hello World";
     tealet_t *coro = tealet_new(main);
-    tealet_run(coro, hello_run, &arg, NULL, TEALET_RUN_SWITCH);
+    tealet_run(coro, hello_run, &arg, NULL, TEALET_START_SWITCH);
     
     /* Clean up */
     tealet_finalize(main);
@@ -175,7 +175,7 @@ tealet_t *my_run(tealet_t *current, void *arg) {
 
 When a run function returns normally, the tealet remains allocated. You must delete it explicitly when done.
 
-**Note:** This does not apply if the run function explicitly exits with `tealet_exit(..., TEALET_EXIT_DELETE)`. In particular, with `TEALET_RUN_SWITCH`, that exit path can free the tealet before `tealet_run()` returns, so the original handle is no longer safe to inspect, reuse, or delete.
+**Note:** This does not apply if the run function explicitly exits with `tealet_exit(..., TEALET_EXIT_DELETE)`. In particular, with `TEALET_START_SWITCH`, that exit path can free the tealet before `tealet_run()` returns, so the original handle is no longer safe to inspect, reuse, or delete.
 
 ```c
 tealet_t *worker_run(tealet_t *current, void *arg) {
@@ -190,7 +190,7 @@ int main(void) {
     void *arg = NULL;
     tealet_t *worker = NULL;
     worker = tealet_new(main);
-    tealet_run(worker, worker_run, &arg, NULL, TEALET_RUN_SWITCH);
+    tealet_run(worker, worker_run, &arg, NULL, TEALET_START_SWITCH);
     /* worker is still valid here */
     
     int status = tealet_status(worker);
@@ -246,7 +246,7 @@ int main(void) {
     /* ... */
     tealet_t *worker = NULL;
     worker = tealet_new(main);
-    tealet_run(worker, controlled_worker, &arg, NULL, TEALET_RUN_SWITCH);
+    tealet_run(worker, controlled_worker, &arg, NULL, TEALET_START_SWITCH);
     
     /* Can switch back to worker multiple times */
     tealet_switch(worker, NULL, TEALET_XFER_DEFAULT);
@@ -296,9 +296,9 @@ int main(void) {
     tealet_t *ping = NULL;
     tealet_t *pong = NULL;
     ping = tealet_new(main);
-    tealet_run(ping, ping_run, NULL, NULL, TEALET_RUN_DEFAULT);
+    tealet_run(ping, ping_run, NULL, NULL, TEALET_START_DEFAULT);
     pong = tealet_new(main);
-    tealet_run(pong, pong_run, NULL, NULL, TEALET_RUN_DEFAULT);
+    tealet_run(pong, pong_run, NULL, NULL, TEALET_START_DEFAULT);
     
     /* Start ping, passing pong as argument */
     void *arg = pong;
@@ -352,7 +352,7 @@ int main(void) {
     void *arg = &max;
     tealet_t *gen = NULL;
     gen = tealet_new(main);
-    tealet_run(gen, range_run, &arg, NULL, TEALET_RUN_SWITCH);
+    tealet_run(gen, range_run, &arg, NULL, TEALET_START_SWITCH);
     
     /* Pull values from generator */
     while (tealet_status(gen) == TEALET_STATUS_ACTIVE) {
@@ -428,14 +428,14 @@ int main(void) {
     /* Create consumer first */
     tealet_t *consumer = NULL;
     consumer = tealet_new(main);
-    tealet_run(consumer, consumer_run, NULL, NULL, TEALET_RUN_DEFAULT);
+    tealet_run(consumer, consumer_run, NULL, NULL, TEALET_START_DEFAULT);
     
     /* Create producer context */
     producer_ctx_t ctx = {consumer, buffer, 0};
     void *arg = &ctx;
     tealet_t *producer = NULL;
     producer = tealet_new(main);
-    tealet_run(producer, producer_run, &arg, NULL, TEALET_RUN_SWITCH);
+    tealet_run(producer, producer_run, &arg, NULL, TEALET_START_SWITCH);
     
     printf("Total consumed: %d items\n", ctx.count);
     
@@ -448,24 +448,24 @@ int main(void) {
 
 ## Creation Patterns
 
-### `tealet_new()` + `tealet_run(..., TEALET_RUN_SWITCH)` - Create and Start Immediately
+### `tealet_new()` + `tealet_run(..., TEALET_START_SWITCH)` - Create and Start Immediately
 
 ```c
 void *arg = my_data;
 tealet_t *t = tealet_new(main);
-tealet_run(t, my_run, &arg, NULL, TEALET_RUN_SWITCH);
+tealet_run(t, my_run, &arg, NULL, TEALET_START_SWITCH);
 /* Returns when my_run switches back */
 /* arg now contains return value */
 ```
 
 Use when you want to start execution immediately.
-Conceptually this is `TEALET_RUN_DEFAULT` + `tealet_switch()`, but `TEALET_RUN_SWITCH` uses an optimized single path that avoids redundant internal state transitions.
+Conceptually this is `TEALET_START_DEFAULT` + `tealet_switch()`, but `TEALET_START_SWITCH` uses an optimized single path that avoids redundant internal state transitions.
 
-### `tealet_new()` + `tealet_run(..., TEALET_RUN_DEFAULT)` + `tealet_switch()` - Deferred Start
+### `tealet_new()` + `tealet_run(..., TEALET_START_DEFAULT)` + `tealet_switch()` - Deferred Start
 
 ```c
 tealet_t *t = tealet_new(main);
-tealet_run(t, my_run, NULL, NULL, TEALET_RUN_DEFAULT);
+tealet_run(t, my_run, NULL, NULL, TEALET_START_DEFAULT);
 /* Tealet created but not yet running */
 
 void *arg = my_data;
@@ -480,7 +480,7 @@ Switching/binding functions return negative error codes on failure:
 
 ```c
 tealet_t *t = tealet_new(main);
-if (tealet_run(t, my_run, NULL, NULL, TEALET_RUN_DEFAULT) != 0) {
+if (tealet_run(t, my_run, NULL, NULL, TEALET_START_DEFAULT) != 0) {
     fprintf(stderr, "Failed to create tealet (out of memory)\n");
     return TEALET_ERR_MEM;
 }
@@ -516,12 +516,12 @@ if (tealet_status(t) == TEALET_STATUS_DEFUNCT) {
 /* Thread 1 */
 tealet_t *main1 = tealet_initialize(&alloc, 0);
 tealet_t *t1 = tealet_new(main1);
-tealet_run(t1, func1, NULL, NULL, TEALET_RUN_DEFAULT);
+tealet_run(t1, func1, NULL, NULL, TEALET_START_DEFAULT);
 
 /* Thread 2 */
 tealet_t *main2 = tealet_initialize(&alloc, 0);
 tealet_t *t2 = tealet_new(main2);
-tealet_run(t2, func2, NULL, NULL, TEALET_RUN_DEFAULT);
+tealet_run(t2, func2, NULL, NULL, TEALET_START_DEFAULT);
 
 /* ❌ WRONG: Can't switch between t1 and t2 (different mains) */
 /* ✅ OK: Can switch within same thread between t1 and other tealets from main1 */

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1391,14 +1391,14 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
   tealet_sub_t *g_exit_target;
   int exit_flags;
   void *exit_arg;
-  int run_on_switch = g_new == g_target; /* true for tealet_run(..., TEALET_RUN_SWITCH) */
+  int run_on_switch = g_new == g_target; /* true for tealet_run(..., TEALET_START_SWITCH) */
   void *run_arg, *switch_arg;
   void *initial_run_arg;
   assert(g_new->stack == NULL); /* it is fresh */
   assert(run);
 
   if (run_on_switch) {
-    /* TEALET_RUN_SWITCH case */
+    /* TEALET_START_SWITCH case */
     assert(parg != NULL);
     /* Capture *parg before switching stacks.  After the switch, the
      * creator's stack region may be snapshot-checked and/or page-guarded,
@@ -1407,7 +1407,7 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
      */
     initial_run_arg = *parg;
   } else {
-    /* TEALET_RUN_DEFAULT case */
+    /* TEALET_START_DEFAULT case */
     assert(parg == NULL);
     initial_run_arg = NULL;
   }
@@ -1432,14 +1432,14 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
      * returning here on a switch, to run the tealet
      */
 
-    /* the following assertion may be invalid, if a TEALET_RUN_DEFAULT tealet
+    /* the following assertion may be invalid, if a TEALET_START_DEFAULT tealet
      * was duplicated.  We may now be a copy
      */
     if (run_on_switch) {
-      assert(g_main->g_current == g_new); /* only valid for TEALET_RUN_SWITCH */
+      assert(g_main->g_current == g_new); /* only valid for TEALET_START_SWITCH */
       run_arg = initial_run_arg;          /* captured before stack switch */
     } else {
-      run_arg = switch_arg; /* TEALET_RUN_DEFAULT: use the arg from the switch */
+      run_arg = switch_arg; /* TEALET_START_DEFAULT: use the arg from the switch */
     }
     assert(g_main->g_current->stack == NULL); /* running */
 
@@ -1465,10 +1465,10 @@ static int tealet_initialstub(tealet_main_t *g_main, tealet_sub_t *g_new, tealet
     abort();
   } else {
     /* Either just a default-mode capture with no run, or a switch back
-     * into the TEALET_RUN_SWITCH caller.
+     * into the TEALET_START_SWITCH caller.
      */
     if (run_on_switch) {
-      /* TEALET_RUN_SWITCH case, switch back - return the switch arg */
+      /* TEALET_START_SWITCH case, switch back - return the switch arg */
       *parg = switch_arg;
     }
   }
@@ -1651,12 +1651,12 @@ int tealet_run(tealet_t *tealet, tealet_run_t run, void **parg, void *stack_far,
   tealet_sub_t *current;
 
   assert(run != NULL);
-  assert((flags & ~TEALET_RUN_SWITCH) == 0);
+  assert((flags & ~TEALET_START_SWITCH) == 0);
 
   if (result->flags != 0)
     return TEALET_ERR_INVAL;
 
-  switch_now = ((flags & TEALET_RUN_SWITCH) != 0);
+  switch_now = ((flags & TEALET_START_SWITCH) != 0);
 
   current = g_main->g_current;
   tealet_verify_current_matches_caller(current);
@@ -1714,9 +1714,9 @@ int tealet_fork(tealet_t *_tealet, void **parg, int flags) {
   g_current = g_main->g_current;
   tealet_verify_current_matches_caller(g_current);
 
-  assert((flags & ~TEALET_RUN_SWITCH) == 0);
+  assert((flags & ~TEALET_START_SWITCH) == 0);
 
-  switch_now = ((flags & TEALET_RUN_SWITCH) != 0);
+  switch_now = ((flags & TEALET_START_SWITCH) != 0);
 
   /* Fork target must be a NEW/unbound tealet */
   if (g_child->flags != 0) {

--- a/src/tealet.c
+++ b/src/tealet.c
@@ -1702,12 +1702,12 @@ done:
  * the lock internally.
  */
 
-int tealet_fork(tealet_t *_tealet, tealet_t **pother, void **parg, int flags) {
+int tealet_fork(tealet_t *_tealet, void **parg, int flags) {
   tealet_sub_t *g_child = (tealet_sub_t *)_tealet;
   tealet_main_t *g_main = TEALET_GET_MAIN(g_child);
   tealet_sub_t *g_current;
   tealet_sub_t *previous;
-  int result, is_parent;
+  int result;
   int switch_now;
   int api_result;
 
@@ -1750,7 +1750,6 @@ int tealet_fork(tealet_t *_tealet, tealet_t **pother, void **parg, int flags) {
   if (switch_now) {
     /* save parent, switch to child*/
     result = tealet_switchstack(g_main, g_child, NULL, parg);
-    is_parent = result == 0;
   } else {
     /* we are just saving the child's stack for later.
      *Save the stack in the child, don't modify 'previous'
@@ -1763,7 +1762,6 @@ int tealet_fork(tealet_t *_tealet, tealet_t **pother, void **parg, int flags) {
      */
     if (result == 1)
       g_main->g_previous = previous;
-    is_parent = result == 1;
   }
 
   if (result < 0) {
@@ -1777,9 +1775,7 @@ int tealet_fork(tealet_t *_tealet, tealet_t **pother, void **parg, int flags) {
     goto done;
   }
 
-  if (pother)
-    *pother = (tealet_t *)(is_parent ? g_child : g_current);
-  api_result = is_parent;
+  api_result = 0;
 
 done:
   /* we are now back.  If successful, we are either conceptually the same stack as when we called,

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -252,11 +252,9 @@ int tealet_run(tealet_t *tealet, tealet_run_t run, void **parg, void *stack_far,
 /**
  * @brief Fork the active tealet by duplicating its execution state.
  * @param tealet NEW/unbound tealet (from tealet_new()) to become the fork child.
- * @param pother Optional out-pointer to the opposite side (parent gets child, child gets parent).
  * @param parg Optional in/out argument pointer passed to whichever side resumes later.
  * @param flags Fork mode: #TEALET_RUN_DEFAULT or #TEALET_RUN_SWITCH.
- * @retval 1 Parent side.
- * @retval 0 Child side.
+ * @retval 0 Success.
  * @retval TEALET_ERR_UNFORKABLE Current stack is unbounded (set far boundary first).
  * @retval TEALET_ERR_MEM Memory failure during stack save/restore.
  * @retval TEALET_ERR_INVAL Invalid target tealet or flags.
@@ -265,14 +263,17 @@ int tealet_run(tealet_t *tealet, tealet_run_t run, void **parg, void *stack_far,
  * of main), exit explicitly via tealet_exit() and do not use #TEALET_EXIT_DEFER.
  *
  * tealet_fork() clones the currently active execution context into @p tealet.
- * Both parent and child resume from the call site:
- * - parent receives return value 1,
- * - child receives return value 0.
+ * Both parent and child resume from the call site.
  *
- * If @p pother is non-NULL, each side receives a pointer to the opposite
- * tealet. If @p parg is non-NULL, it carries one pointer value to the side
+ * If @p parg is non-NULL, it carries one pointer value to the side
  * that resumes later (matching #TEALET_RUN_DEFAULT / #TEALET_RUN_SWITCH
  * suspension behavior).
+ *
+ * To detect side on return, use:
+ * - child side: tealet_current(tealet) == tealet
+ * - parent side: tealet_current(tealet) != tealet
+ *
+ * To obtain the opposite side at first resume, use tealet_previous().
  *
  * Prerequisites:
  * - @p tealet must be NEW/unbound.
@@ -282,7 +283,7 @@ int tealet_run(tealet_t *tealet, tealet_run_t run, void **parg, void *stack_far,
  * The child inherits the current far boundary at fork time.
  */
 TEALET_API
-int tealet_fork(tealet_t *tealet, tealet_t **pother, void **parg, int flags);
+int tealet_fork(tealet_t *tealet, void **parg, int flags);
 
 /**
  * @brief Suspend current tealet and resume @p target.
@@ -532,7 +533,7 @@ void tealet_reset_peak_stats(tealet_t *t);
  *       tealet_set_far(main, far_marker);
  *
  *       int local_var = 0;
- *       tealet_fork(child, &child, 0, TEALET_RUN_DEFAULT);
+ *       tealet_fork(child, 0, TEALET_RUN_DEFAULT);
  *   }
  *
  * Alternative (far_boundary from same function, requires care):
@@ -544,7 +545,7 @@ void tealet_reset_peak_stats(tealet_t *t);
  *       tealet_set_far(main, &far_marker);
  *
  *       int local_var = 0;
- *       tealet_fork(child, &child, 0, TEALET_RUN_DEFAULT);
+ *       tealet_fork(child, 0, TEALET_RUN_DEFAULT);
  *   }
  *
  * By providing this address, you promise that no stack data beyond (further

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -229,7 +229,7 @@ tealet_t *tealet_new(tealet_t *tealet);
  * @param run Callable entry function for the target.
  * @param parg Optional in/out switch argument pointer; used when #TEALET_START_SWITCH is set.
  * @param stack_far Optional minimum far-boundary requirement for the initial stack snapshot.
- * @param flags Run mode: #TEALET_START_DEFAULT or #TEALET_START_SWITCH.
+ * @param flags Start mode: #TEALET_START_DEFAULT or #TEALET_START_SWITCH.
  * @return 0 on success, negative #TEALET_ERR_* on failure.
  *
  * This API installs @p run on a NEW tealet and captures its initial saved

--- a/src/tealet.h
+++ b/src/tealet.h
@@ -219,29 +219,29 @@ void tealet_finalize(tealet_t *tealet);
 TEALET_API
 tealet_t *tealet_new(tealet_t *tealet);
 
-/* tealet_run flags */
-#define TEALET_RUN_DEFAULT 0 /* capture initial stack state, do not switch to target */
-#define TEALET_RUN_SWITCH 1  /* capture initial stack state and immediately switch to target */
+/* start mode flags shared by tealet_run() and tealet_fork() */
+#define TEALET_START_DEFAULT 0 /* capture initial stack state, do not switch to target */
+#define TEALET_START_SWITCH 1  /* capture initial stack state and immediately switch to target */
 
 /**
  * @brief Run a callable on a NEW tealet, immediately or by binding for later resume.
  * @param tealet NEW/unbound target tealet (typically from tealet_new()).
  * @param run Callable entry function for the target.
- * @param parg Optional in/out switch argument pointer; used when #TEALET_RUN_SWITCH is set.
+ * @param parg Optional in/out switch argument pointer; used when #TEALET_START_SWITCH is set.
  * @param stack_far Optional minimum far-boundary requirement for the initial stack snapshot.
- * @param flags Run mode: #TEALET_RUN_DEFAULT or #TEALET_RUN_SWITCH.
+ * @param flags Run mode: #TEALET_START_DEFAULT or #TEALET_START_SWITCH.
  * @return 0 on success, negative #TEALET_ERR_* on failure.
  *
  * This API installs @p run on a NEW tealet and captures its initial saved
  * stack state.
- * With #TEALET_RUN_SWITCH, it switches to the target immediately.
- * Conceptually, #TEALET_RUN_SWITCH is equivalent to
- * #TEALET_RUN_DEFAULT followed by tealet_switch(), but uses an optimized
+ * With #TEALET_START_SWITCH, it switches to the target immediately.
+ * Conceptually, #TEALET_START_SWITCH is equivalent to
+ * #TEALET_START_DEFAULT followed by tealet_switch(), but uses an optimized
  * single path that avoids redundant internal state transitions.
- * With #TEALET_RUN_DEFAULT, it returns to caller after capture; execution
+ * With #TEALET_START_DEFAULT, it returns to caller after capture; execution
  * starts on a later tealet_switch() to that target.
  *
- * @warning With #TEALET_RUN_SWITCH, @p run may return/exit before
+ * @warning With #TEALET_START_SWITCH, @p run may return/exit before
  * tealet_run() returns to the caller. If that path uses
  * tealet_exit(..., #TEALET_EXIT_DELETE), the @p tealet handle can become
  * invalid before tealet_run() returns.
@@ -253,7 +253,7 @@ int tealet_run(tealet_t *tealet, tealet_run_t run, void **parg, void *stack_far,
  * @brief Fork the active tealet by duplicating its execution state.
  * @param tealet NEW/unbound tealet (from tealet_new()) to become the fork child.
  * @param parg Optional in/out argument pointer passed to whichever side resumes later.
- * @param flags Fork mode: #TEALET_RUN_DEFAULT or #TEALET_RUN_SWITCH.
+ * @param flags Fork mode: #TEALET_START_DEFAULT or #TEALET_START_SWITCH.
  * @retval 0 Success.
  * @retval TEALET_ERR_UNFORKABLE Current stack is unbounded (set far boundary first).
  * @retval TEALET_ERR_MEM Memory failure during stack save/restore.
@@ -266,7 +266,7 @@ int tealet_run(tealet_t *tealet, tealet_run_t run, void **parg, void *stack_far,
  * Both parent and child resume from the call site.
  *
  * If @p parg is non-NULL, it carries one pointer value to the side
- * that resumes later (matching #TEALET_RUN_DEFAULT / #TEALET_RUN_SWITCH
+ * that resumes later (matching #TEALET_START_DEFAULT / #TEALET_START_SWITCH
  * suspension behavior).
  *
  * To detect side on return, use:
@@ -533,7 +533,7 @@ void tealet_reset_peak_stats(tealet_t *t);
  *       tealet_set_far(main, far_marker);
  *
  *       int local_var = 0;
- *       tealet_fork(child, 0, TEALET_RUN_DEFAULT);
+ *       tealet_fork(child, 0, TEALET_START_DEFAULT);
  *   }
  *
  * Alternative (far_boundary from same function, requires care):
@@ -545,7 +545,7 @@ void tealet_reset_peak_stats(tealet_t *t);
  *       tealet_set_far(main, &far_marker);
  *
  *       int local_var = 0;
- *       tealet_fork(child, 0, TEALET_RUN_DEFAULT);
+ *       tealet_fork(child, 0, TEALET_START_DEFAULT);
  *   }
  *
  * By providing this address, you promise that no stack data beyond (further

--- a/src/tealet_extras.c
+++ b/src/tealet_extras.c
@@ -40,7 +40,7 @@ int tealet_spawn(tealet_t *tealet, tealet_t **pcreated, tealet_run_t run, void *
   tealet_t *created;
   int result;
 
-  if ((flags & ~TEALET_RUN_SWITCH) != 0)
+  if ((flags & ~TEALET_START_SWITCH) != 0)
     return TEALET_ERR_INVAL;
   if (run == NULL)
     return TEALET_ERR_INVAL;
@@ -91,7 +91,7 @@ static tealet_t *_tealet_stub_main(tealet_t *current, void *arg) {
 
 /* create a stub and return it */
 int tealet_stub_new(tealet_t *t, tealet_t **pstub, void *stack_far) {
-  return tealet_spawn(t, pstub, _tealet_stub_main, NULL, stack_far, TEALET_RUN_DEFAULT);
+  return tealet_spawn(t, pstub, _tealet_stub_main, NULL, stack_far, TEALET_START_DEFAULT);
 }
 
 /*

--- a/src/tealet_extras.h
+++ b/src/tealet_extras.h
@@ -24,7 +24,7 @@ void tealet_statsalloc_init(tealet_statsalloc_t *alloc, tealet_alloc_t *base);
  * Convenience creation wrappers built on tealet_new() + tealet_run().
  */
 
-/* Allocate a NEW tealet and run it according to TEALET_RUN_* flags. */
+/* Allocate a NEW tealet and run it according to TEALET_START_* flags. */
 TEALET_API
 int tealet_spawn(tealet_t *tealet, tealet_t **pcreated, tealet_run_t run, void **parg, void *stack_far, int flags);
 

--- a/tests/setcontext.c
+++ b/tests/setcontext.c
@@ -66,7 +66,7 @@ int main(void) {
     tealet_finalize(tmain);
     return 1;
   }
-  if (tealet_run(loop, loop_func, &data, NULL, TEALET_RUN_SWITCH) != 0) {
+  if (tealet_run(loop, loop_func, &data, NULL, TEALET_START_SWITCH) != 0) {
     tealet_delete(loop);
     tealet_test_lock_assert_balanced(&g_lock_state);
     tealet_finalize(tmain);

--- a/tests/test_chunks.c
+++ b/tests/test_chunks.c
@@ -81,7 +81,7 @@ int main(void) {
     tealet_finalize(g_main);
     return 1;
   }
-  if (tealet_run(t1, worker_run, NULL, NULL, TEALET_RUN_SWITCH) != 0) {
+  if (tealet_run(t1, worker_run, NULL, NULL, TEALET_START_SWITCH) != 0) {
     fprintf(stderr, "Failed to start tealet\n");
     tealet_delete(t1);
     tealet_test_lock_assert_balanced(&g_lock_state);

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -32,7 +32,7 @@ static int prepare_worker(tealet_t *main_tealet, tealet_t **pworker, tealet_run_
   if (worker == NULL)
     return TEALET_ERR_MEM;
 
-  result = tealet_run(worker, run, NULL, NULL, TEALET_RUN_DEFAULT);
+  result = tealet_run(worker, run, NULL, NULL, TEALET_START_DEFAULT);
   if (result != 0) {
     tealet_delete(worker);
     return result;

--- a/tests/test_fork.c
+++ b/tests/test_fork.c
@@ -60,6 +60,7 @@ static void test_basic_fork(void *far_marker) {
   tealet_t *main;
   tealet_t *other = NULL;
   int result;
+  int is_child;
 
   TEST("test_basic_fork");
 
@@ -77,9 +78,14 @@ static void test_basic_fork(void *far_marker) {
   assert(other != NULL);
 
   /* Fork - creates child but stays in parent */
-  result = tealet_fork(other, &other, NULL, TEALET_RUN_DEFAULT);
+  result = tealet_fork(other, NULL, TEALET_RUN_DEFAULT);
+  if (result != 0) {
+    printf("  Error: fork returned %d\n", result);
+    assert(0);
+  }
+  is_child = (tealet_current(other) == other);
 
-  if (result == 1) {
+  if (!is_child) {
     /* We are the parent, other = child */
     assert(other != NULL);
     assert_origin_main(main);
@@ -105,9 +111,10 @@ static void test_basic_fork(void *far_marker) {
     finalize_main_checked(main);
 
     PASS();
-  } else if (result == 0) {
+  } else if (is_child) {
     /* We are the child, other = parent */
     tealet_test_lock_assert_unheld(&g_lock_state);
+    other = tealet_previous(main);
     assert_origin_main_fork(tealet_current(main));
     assert_origin_main(other);
     assert(testvalue == 0); /* Child should start with saved value */
@@ -128,10 +135,6 @@ static void test_basic_fork(void *far_marker) {
 
     printf("  Child: this should never print\n");
     assert(0);
-  } else {
-    /* Error */
-    printf("  Error: fork returned %d\n", result);
-    assert(0);
   }
 }
 
@@ -140,6 +143,7 @@ static void test_fork_switch(void *far_marker) {
   tealet_t *main;
   tealet_t *other = NULL;
   int result;
+  int is_child;
   int switch_count = 0;
 
   TEST("test_fork_switch");
@@ -159,13 +163,16 @@ static void test_fork_switch(void *far_marker) {
   assert(other != NULL);
 
   /* Fork with immediate switch - becomes child immediately */
-  result = tealet_fork(other, &other, NULL, TEALET_RUN_SWITCH);
+  result = tealet_fork(other, NULL, TEALET_RUN_SWITCH);
+  assert(result == 0);
+  is_child = (tealet_current(other) == other);
 
   switch_count++;
 
-  if (result == 0) {
+  if (is_child) {
     /* We are the child */
     tealet_test_lock_assert_unheld(&g_lock_state);
+    other = tealet_previous(main);
     assert_origin_main_fork(tealet_current(main));
     assert_origin_main(other);
     assert(testvalue == 0);    /* Child should start with saved value */
@@ -186,7 +193,7 @@ static void test_fork_switch(void *far_marker) {
     assert(0);
   } else {
     /* We are the parent, switched back to */
-    assert(result == 1);
+    assert(!is_child);
     assert_origin_main(main);
     assert_origin_main_fork(other);
     assert(testvalue == 0);    /* Parent should have saved value, not child's 42 */
@@ -210,6 +217,7 @@ static void test_multiple_forks(void *far_marker) {
   tealet_t *child1 = NULL;
   tealet_t *child2 = NULL;
   int result;
+  int is_child;
   int visited = 0;
 
   TEST("test_multiple_forks");
@@ -225,13 +233,17 @@ static void test_multiple_forks(void *far_marker) {
   /* Create first child */
   child1 = tealet_new(main);
   assert(child1 != NULL);
-  result = tealet_fork(child1, &child1, NULL, TEALET_RUN_DEFAULT);
-  if (result == 0) {
+  result = tealet_fork(child1, NULL, TEALET_RUN_DEFAULT);
+  assert(result == 0);
+  is_child = (tealet_current(child1) == child1);
+  if (is_child) {
+    child1 = tealet_previous(main);
     /* We are child1 */
     printf("  Child1: woke up, exiting\n");
     tealet_exit(child1, NULL, 0);
     assert(0);
   }
+  assert(!is_child);
   assert(child1 != NULL);
   assert_origin_main_fork(child1);
   printf("  Parent: created child1=%p\n", (void *)child1);
@@ -239,13 +251,17 @@ static void test_multiple_forks(void *far_marker) {
   /* Create second child */
   child2 = tealet_new(main);
   assert(child2 != NULL);
-  result = tealet_fork(child2, &child2, NULL, TEALET_RUN_DEFAULT);
-  if (result == 0) {
+  result = tealet_fork(child2, NULL, TEALET_RUN_DEFAULT);
+  assert(result == 0);
+  is_child = (tealet_current(child2) == child2);
+  if (is_child) {
+    child2 = tealet_previous(main);
     /* We are child2 */
     printf("  Child2: woke up, exiting\n");
     tealet_exit(child2, NULL, 0);
     assert(0);
   }
+  assert(!is_child);
   assert(child2 != NULL);
   assert_origin_main_fork(child2);
   printf("  Parent: created child2=%p\n", (void *)child2);
@@ -277,6 +293,7 @@ static void test_fork_switch_arg(void *far_marker) {
   tealet_t *main;
   tealet_t *other = NULL;
   int result;
+  int is_child;
   void *arg = NULL;
 
   TEST("test_fork_switch_arg");
@@ -293,11 +310,14 @@ static void test_fork_switch_arg(void *far_marker) {
    */
   other = tealet_new(main);
   assert(other != NULL);
-  result = tealet_fork(other, &other, &arg, TEALET_RUN_SWITCH);
+  result = tealet_fork(other, &arg, TEALET_RUN_SWITCH);
+  assert(result == 0);
+  is_child = (tealet_current(other) == other);
 
-  if (result == 0) {
+  if (is_child) {
     /* We are the child - arg should be NULL initially */
     void *childarg;
+    other = tealet_previous(main);
     assert_origin_main_fork(tealet_current(main));
     assert_origin_main(other);
     assert(arg == NULL);
@@ -318,7 +338,7 @@ static void test_fork_switch_arg(void *far_marker) {
   } else {
     /* We are the parent - child should have passed back a value */
     void *parentarg;
-    assert(result == 1);
+    assert(!is_child);
     assert_origin_main(main);
     assert_origin_main_fork(other);
     printf("  Parent: received arg=%p from child\n", arg);
@@ -345,6 +365,7 @@ static void test_fork_default_arg(void *far_marker) {
   tealet_t *main;
   tealet_t *child = NULL;
   int result;
+  int is_child;
   void *arg = NULL;
 
   TEST("test_fork_default_arg");
@@ -360,9 +381,11 @@ static void test_fork_default_arg(void *far_marker) {
   /* Fork without FORK_SWITCH - stays in parent */
   child = tealet_new(main);
   assert(child != NULL);
-  result = tealet_fork(child, &child, &arg, TEALET_RUN_DEFAULT);
+  result = tealet_fork(child, &arg, TEALET_RUN_DEFAULT);
+  assert(result == 0);
+  is_child = (tealet_current(child) == child);
 
-  if (result == 1) {
+  if (!is_child) {
     /* We are the parent - arg should still be NULL */
     void *parentarg;
     assert(arg == NULL);
@@ -385,23 +408,20 @@ static void test_fork_default_arg(void *far_marker) {
     finalize_main_checked(main);
 
     PASS();
-  } else if (result == 0) {
+  } else if (is_child) {
     /* We are the child - arg should have the value parent passed */
     void *childarg;
+    tealet_t *parent = tealet_previous(main);
     assert_origin_main_fork(tealet_current(main));
-    assert_origin_main(child);
+    assert_origin_main(parent);
     printf("  Child: woke up with arg=%p\n", arg);
     assert(arg == (void *)0xABCDEF00);
 
     /* Switch back to parent with a different value */
     childarg = (void *)0xDEADBEEF;
-    tealet_switch(child, &childarg, TEALET_XFER_DEFAULT); /* child pointer is parent from child's perspective */
+    tealet_switch(parent, &childarg, TEALET_XFER_DEFAULT);
 
     printf("  Child: this should never print\n");
-    assert(0);
-  } else {
-    /* Error */
-    printf("  Error: fork returned %d\n", result);
     assert(0);
   }
 }
@@ -411,6 +431,7 @@ static void test_ping_pong(void *far_marker) {
   tealet_t *main;
   tealet_t *child = NULL;
   int result;
+  int is_child;
   int counter = 0;
 
   TEST("test_ping_pong");
@@ -429,11 +450,13 @@ static void test_ping_pong(void *far_marker) {
   /* Fork */
   child = tealet_new(main);
   assert(child != NULL);
-  result = tealet_fork(child, &child, NULL, TEALET_RUN_DEFAULT);
+  result = tealet_fork(child, NULL, TEALET_RUN_DEFAULT);
+  assert(result == 0);
+  is_child = (tealet_current(child) == child);
 
   counter++;
 
-  if (result == 1) {
+  if (!is_child) {
     /* Parent */
     tealet_t *child_saved = child; /* Save - local vars on swapped stack */
     assert_origin_main(child_saved->main);
@@ -465,9 +488,10 @@ static void test_ping_pong(void *far_marker) {
     PASS();
   } else {
     /* Child */
-    assert(result == 0);
+    tealet_t *parent = tealet_previous(main);
+    assert(is_child);
     assert_origin_main_fork(tealet_current(main));
-    assert_origin_main(child);
+    assert_origin_main(parent);
     printf("  Child: counter=%d, data=[%d,%d,%d,%d,%d], switching to parent\n", counter, data[0], data[1], data[2],
            data[3], data[4]);
 
@@ -475,7 +499,7 @@ static void test_ping_pong(void *far_marker) {
       /* Child increments by 10 each iteration (counter goes 1,2,3,4 -> indices
        * 0,1,2,3) */
       data[counter - 1] += 10;
-      tealet_switch(child, NULL, TEALET_XFER_DEFAULT); /* child pointer is parent from child's perspective */
+      tealet_switch(parent, NULL, TEALET_XFER_DEFAULT);
       counter++;
       printf("  Child: counter=%d, data=[%d,%d,%d,%d,%d], switching to parent\n", counter, data[0], data[1], data[2],
              data[3], data[4]);
@@ -487,7 +511,7 @@ static void test_ping_pong(void *far_marker) {
 
     /* Final switch back to parent for cleanup */
     printf("  Child: exiting\n");
-    tealet_exit(child, NULL, 0);
+    tealet_exit(parent, NULL, 0);
   }
 }
 

--- a/tests/test_fork.c
+++ b/tests/test_fork.c
@@ -55,7 +55,7 @@ static tealet_t *new_main_checked(void) {
   return main;
 }
 
-/* Test basic fork without TEALET_RUN_SWITCH */
+/* Test basic fork without TEALET_START_SWITCH */
 static void test_basic_fork(void *far_marker) {
   tealet_t *main;
   tealet_t *other = NULL;
@@ -78,7 +78,7 @@ static void test_basic_fork(void *far_marker) {
   assert(other != NULL);
 
   /* Fork - creates child but stays in parent */
-  result = tealet_fork(other, NULL, TEALET_RUN_DEFAULT);
+  result = tealet_fork(other, NULL, TEALET_START_DEFAULT);
   if (result != 0) {
     printf("  Error: fork returned %d\n", result);
     assert(0);
@@ -138,7 +138,7 @@ static void test_basic_fork(void *far_marker) {
   }
 }
 
-/* Test fork with TEALET_RUN_SWITCH */
+/* Test fork with TEALET_START_SWITCH */
 static void test_fork_switch(void *far_marker) {
   tealet_t *main;
   tealet_t *other = NULL;
@@ -163,7 +163,7 @@ static void test_fork_switch(void *far_marker) {
   assert(other != NULL);
 
   /* Fork with immediate switch - becomes child immediately */
-  result = tealet_fork(other, NULL, TEALET_RUN_SWITCH);
+  result = tealet_fork(other, NULL, TEALET_START_SWITCH);
   assert(result == 0);
   is_child = (tealet_current(other) == other);
 
@@ -233,7 +233,7 @@ static void test_multiple_forks(void *far_marker) {
   /* Create first child */
   child1 = tealet_new(main);
   assert(child1 != NULL);
-  result = tealet_fork(child1, NULL, TEALET_RUN_DEFAULT);
+  result = tealet_fork(child1, NULL, TEALET_START_DEFAULT);
   assert(result == 0);
   is_child = (tealet_current(child1) == child1);
   if (is_child) {
@@ -251,7 +251,7 @@ static void test_multiple_forks(void *far_marker) {
   /* Create second child */
   child2 = tealet_new(main);
   assert(child2 != NULL);
-  result = tealet_fork(child2, NULL, TEALET_RUN_DEFAULT);
+  result = tealet_fork(child2, NULL, TEALET_START_DEFAULT);
   assert(result == 0);
   is_child = (tealet_current(child2) == child2);
   if (is_child) {
@@ -288,7 +288,7 @@ static void test_multiple_forks(void *far_marker) {
   PASS();
 }
 
-/* Test fork argument passing with TEALET_RUN_SWITCH */
+/* Test fork argument passing with TEALET_START_SWITCH */
 static void test_fork_switch_arg(void *far_marker) {
   tealet_t *main;
   tealet_t *other = NULL;
@@ -310,7 +310,7 @@ static void test_fork_switch_arg(void *far_marker) {
    */
   other = tealet_new(main);
   assert(other != NULL);
-  result = tealet_fork(other, &arg, TEALET_RUN_SWITCH);
+  result = tealet_fork(other, &arg, TEALET_START_SWITCH);
   assert(result == 0);
   is_child = (tealet_current(other) == other);
 
@@ -360,7 +360,7 @@ static void test_fork_switch_arg(void *far_marker) {
   PASS();
 }
 
-/* Test fork argument passing with TEALET_RUN_DEFAULT */
+/* Test fork argument passing with TEALET_START_DEFAULT */
 static void test_fork_default_arg(void *far_marker) {
   tealet_t *main;
   tealet_t *child = NULL;
@@ -381,7 +381,7 @@ static void test_fork_default_arg(void *far_marker) {
   /* Fork without FORK_SWITCH - stays in parent */
   child = tealet_new(main);
   assert(child != NULL);
-  result = tealet_fork(child, &arg, TEALET_RUN_DEFAULT);
+  result = tealet_fork(child, &arg, TEALET_START_DEFAULT);
   assert(result == 0);
   is_child = (tealet_current(child) == child);
 
@@ -450,7 +450,7 @@ static void test_ping_pong(void *far_marker) {
   /* Fork */
   child = tealet_new(main);
   assert(child != NULL);
-  result = tealet_fork(child, NULL, TEALET_RUN_DEFAULT);
+  result = tealet_fork(child, NULL, TEALET_START_DEFAULT);
   assert(result == 0);
   is_child = (tealet_current(child) == child);
 
@@ -542,7 +542,7 @@ static void test_new_previous(void *far_marker) {
   arg = main;
   started = tealet_new(main);
   assert(started != NULL);
-  assert(tealet_run(started, test_new_previous_run, &arg, NULL, TEALET_RUN_SWITCH) == 0);
+  assert(tealet_run(started, test_new_previous_run, &arg, NULL, TEALET_START_SWITCH) == 0);
 
   /* Verify tealet_previous() after return from tealet_run() */
   /* With default return behavior, the started tealet remains allocated until

--- a/tests/test_lifecycle.c
+++ b/tests/test_lifecycle.c
@@ -102,7 +102,7 @@ void test_simple_create(void) {
   tealet_t *t;
   init_test();
   t = NULL;
-  assert(tealet_spawn(g_main, &t, test_simple_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &t, test_simple_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   assert(status == 0);
   tealet_delete(t);
   fini_test();
@@ -115,7 +115,7 @@ void test_simple_create_and_run(void) {
   tealet_t *t;
   init_test();
   t = NULL;
-  assert(tealet_spawn(g_main, &t, test_simple_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &t, test_simple_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   tealet_switch(t, NULL, TEALET_XFER_DEFAULT);
   assert(status == 1);
   assert(tealet_previous(g_main) == t);
@@ -142,7 +142,7 @@ void test_create_previous(void) {
   init_test();
   /* Create tealet without running it */
   t = NULL;
-  assert(tealet_spawn(g_main, &t, test_create_previous_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &t, test_create_previous_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   assert(status == 0);
   /* Now switch to it - it should see main as previous */
   tealet_switch(t, NULL, TEALET_XFER_DEFAULT);
@@ -167,7 +167,7 @@ void test_previous_cleared_on_manual_delete(void) {
 
   init_test();
   t = NULL;
-  assert(tealet_spawn(g_main, &t, test_previous_manual_delete_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &t, test_previous_manual_delete_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   assert(t != NULL);
 
   tealet_switch(t, NULL, TEALET_XFER_DEFAULT);

--- a/tests/test_locking.c
+++ b/tests/test_locking.c
@@ -137,7 +137,7 @@ void test_lock_transitions_fork(void) {
   assert(other != NULL);
 
   lock_snapshot_take(&g_lock_fork_before);
-  result = tealet_fork(other, NULL, TEALET_RUN_DEFAULT);
+  result = tealet_fork(other, NULL, TEALET_START_DEFAULT);
   assert(result == 0);
   lock_snapshot_assert_delta_one(&g_lock_fork_before);
 

--- a/tests/test_locking.c
+++ b/tests/test_locking.c
@@ -125,6 +125,7 @@ void test_lock_transitions_stub(void) {
 void test_lock_transitions_fork(void) {
   tealet_t *other = NULL;
   int result;
+  int is_child;
   char far_marker = 0;
 
   init_test();
@@ -136,10 +137,13 @@ void test_lock_transitions_fork(void) {
   assert(other != NULL);
 
   lock_snapshot_take(&g_lock_fork_before);
-  result = tealet_fork(other, &other, NULL, TEALET_RUN_DEFAULT);
+  result = tealet_fork(other, NULL, TEALET_RUN_DEFAULT);
+  assert(result == 0);
   lock_snapshot_assert_delta_one(&g_lock_fork_before);
 
-  if (result == 1) {
+  is_child = (tealet_current(other) == other);
+
+  if (!is_child) {
     assert(other != NULL);
     tealet_delete(other);
     fini_test();
@@ -147,7 +151,8 @@ void test_lock_transitions_fork(void) {
   }
 
   /* If we execute as child, this path should not continue after exit. */
-  assert(result == 0);
+  assert(is_child);
+  other = tealet_previous(g_main);
   test_lock_assert_unheld();
   tealet_exit(other, NULL, 0);
   abort();

--- a/tests/test_resilience.c
+++ b/tests/test_resilience.c
@@ -72,7 +72,7 @@ void test_oom_force_marks_source_defunct(void) {
   init_test_extra(NULL, 0);
 
   worker = NULL;
-  assert(tealet_spawn(g_main, &worker, oom_force_to_main_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &worker, oom_force_to_main_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   assert(worker != NULL);
 
   result = tealet_switch(worker, NULL, TEALET_XFER_DEFAULT);
@@ -102,7 +102,7 @@ void test_oom_force_main_not_defunct(void) {
   init_test_extra(NULL, 0);
 
   worker = NULL;
-  assert(tealet_spawn(g_main, &worker, oom_main_probe_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &worker, oom_main_probe_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   assert(worker != NULL);
 
   talloc_fail = 1;
@@ -155,11 +155,11 @@ void test_oom_force_peer_then_panic_main(void) {
   init_test_extra(NULL, 0);
 
   oom_w2 = NULL;
-  assert(tealet_spawn(g_main, &oom_w2, oom_force_peer_to_main_panic_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &oom_w2, oom_force_peer_to_main_panic_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   assert(oom_w2 != NULL);
 
   w1 = NULL;
-  assert(tealet_spawn(g_main, &w1, oom_force_to_peer_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &w1, oom_force_to_peer_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   assert(w1 != NULL);
 
   result = tealet_switch(w1, NULL, TEALET_XFER_DEFAULT);
@@ -198,7 +198,7 @@ void test_switch_nofail_retries_force(void) {
   init_test_extra(NULL, 0);
 
   worker = NULL;
-  assert(tealet_spawn(g_main, &worker, switch_nofail_mem_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &worker, switch_nofail_mem_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   assert(worker != NULL);
 
   result = tealet_switch(worker, NULL, TEALET_XFER_DEFAULT);
@@ -231,7 +231,7 @@ void test_switch_nofail_defunct_target_panics_main(void) {
   init_test_extra(NULL, 0);
 
   victim = NULL;
-  assert(tealet_spawn(g_main, &victim, oom_force_to_main_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &victim, oom_force_to_main_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   assert(victim != NULL);
 
   result = tealet_switch(victim, NULL, TEALET_XFER_DEFAULT);
@@ -240,7 +240,7 @@ void test_switch_nofail_defunct_target_panics_main(void) {
   assert(tealet_status(victim) == TEALET_STATUS_DEFUNCT);
 
   switcher = NULL;
-  assert(tealet_spawn(g_main, &switcher, switch_nofail_defunct_target_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &switcher, switch_nofail_defunct_target_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   assert(switcher != NULL);
   arg = (void *)victim;
   result = tealet_switch(switcher, &arg, TEALET_XFER_DEFAULT);
@@ -273,7 +273,7 @@ void test_exit_nofail_retries_force(void) {
   init_test_extra(NULL, 0);
 
   worker = NULL;
-  assert(tealet_spawn(g_main, &worker, exit_nofail_mem_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &worker, exit_nofail_mem_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   assert(worker != NULL);
 
   result = tealet_switch(worker, NULL, TEALET_XFER_DEFAULT);
@@ -306,7 +306,7 @@ void test_exit_nofail_defunct_target_panics_main(void) {
   init_test_extra(NULL, 0);
 
   victim = NULL;
-  assert(tealet_spawn(g_main, &victim, oom_force_to_main_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &victim, oom_force_to_main_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   assert(victim != NULL);
 
   result = tealet_switch(victim, NULL, TEALET_XFER_DEFAULT);
@@ -315,7 +315,7 @@ void test_exit_nofail_defunct_target_panics_main(void) {
   assert(tealet_status(victim) == TEALET_STATUS_DEFUNCT);
 
   exiter = NULL;
-  assert(tealet_spawn(g_main, &exiter, exit_nofail_defunct_target_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &exiter, exit_nofail_defunct_target_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   assert(exiter != NULL);
   arg = (void *)victim;
   result = tealet_switch(exiter, &arg, TEALET_XFER_DEFAULT);
@@ -347,7 +347,7 @@ void test_exit_self_invalid(void) {
   init_test();
 
   runner = NULL;
-  assert(tealet_spawn(g_main, &runner, test_exit_self_invalid_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &runner, test_exit_self_invalid_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   assert(runner != NULL);
   assert(tealet_switch(runner, NULL, TEALET_XFER_DEFAULT) == 0);
 
@@ -398,7 +398,7 @@ void test_exit_defunct_target_returns_error(void) {
   assert(result == 0);
 
   exiter = NULL;
-  assert(tealet_spawn(g_main, &exiter, test_exit_defunct_fail_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &exiter, test_exit_defunct_fail_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   assert(exiter != NULL);
   arg = (void *)victim;
   result = tealet_switch(exiter, &arg, TEALET_XFER_DEFAULT);
@@ -428,7 +428,7 @@ void test_exit_explicit_panic(void) {
   init_test();
 
   exiter = NULL;
-  assert(tealet_spawn(g_main, &exiter, test_explicit_panic_exit_run, NULL, NULL, TEALET_RUN_DEFAULT) == 0);
+  assert(tealet_spawn(g_main, &exiter, test_explicit_panic_exit_run, NULL, NULL, TEALET_START_DEFAULT) == 0);
   assert(exiter != NULL);
   arg = (void *)g_main;
   result = tealet_switch(exiter, &arg, TEALET_XFER_DEFAULT);

--- a/tests/test_stochastic.c
+++ b/tests/test_stochastic.c
@@ -187,7 +187,7 @@ static int worker_recursive(tealet_t *current, int depth) {
       void *arg = NULL;
       tealet_t *created = tealet_new(current);
       if (created != NULL) {
-        if (tealet_run(created, worker_entry, &arg, NULL, TEALET_RUN_SWITCH) != 0)
+        if (tealet_run(created, worker_entry, &arg, NULL, TEALET_START_SWITCH) != 0)
           tealet_delete(created);
       }
       continue;

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -222,7 +222,7 @@ static int tealet_new_x(tealet_t *m, tealet_t **out, tealet_run_t run, void **pa
   counter += 1;
   if (counter % 2) {
     r = NULL;
-    rc = tealet_spawn(m, &r, run, parg, stack_far, TEALET_RUN_SWITCH);
+    rc = tealet_spawn(m, &r, run, parg, stack_far, TEALET_START_SWITCH);
     if (rc != 0)
       return rc;
     *out = r;
@@ -230,7 +230,7 @@ static int tealet_new_x(tealet_t *m, tealet_t **out, tealet_run_t run, void **pa
   }
 
   r = NULL;
-  rc = tealet_spawn(m, &r, run, NULL, stack_far, TEALET_RUN_DEFAULT);
+  rc = tealet_spawn(m, &r, run, NULL, stack_far, TEALET_START_DEFAULT);
   if (rc != 0)
     return rc;
   i = tealet_switch(r, parg, TEALET_XFER_DEFAULT);
@@ -244,7 +244,7 @@ static int tealet_new_x(tealet_t *m, tealet_t **out, tealet_run_t run, void **pa
 
 tealet_t *tealet_new_native_call(tealet_t *m, tealet_run_t run, void **parg, void *stack_far) {
   tealet_t *r = NULL;
-  int rc = tealet_spawn(m, &r, run, parg, stack_far, TEALET_RUN_SWITCH);
+  int rc = tealet_spawn(m, &r, run, parg, stack_far, TEALET_START_SWITCH);
   if (rc != 0)
     return NULL;
   return r;


### PR DESCRIPTION
## Summary
- simplify tealet_fork() by removing side out-parameter complexity and using runtime side detection
- rename shared start-mode constants from TEALET_RUN_* to TEALET_START_* for run/fork/spawn orthogonality
- update docs/examples and tests to match the new API

## Details
- tealet_fork(tealet_t *tealet, void **parg, int flags) now has a smaller surface
- child and parent side detection is documented and exercised via tealet_current(child) == child
- TEALET_START_DEFAULT and TEALET_START_SWITCH replace TEALET_RUN_DEFAULT and TEALET_RUN_SWITCH

## Validation
- make test passes on this branch